### PR TITLE
#31 User-agent header

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -12,6 +12,7 @@ import {
     ForkOptions, LanguageClient, LanguageClientOptions, ServerOptions, TransportKind,
 } from "vscode-languageclient";
 import { AxibaseChartsProvider, IConnectionDetails } from "./axibaseChartsProvider";
+import { userAgent } from "./util";
 
 const configSection: string = "axibaseCharts";
 export const languageId: string = "axibasecharts";
@@ -199,7 +200,7 @@ const performRequest: (address: string, username: string, password: string) => P
         const options: RequestOptions = {
             headers: {
                 "Authorization": `Basic ${new Buffer(`${username}:${password}`).toString("base64")}`,
-                "user-agent": "axibase-charts-vscode",
+                "user-agent": userAgent,
             },
             hostname: url.hostname,
             method: "GET",

--- a/client/src/util.ts
+++ b/client/src/util.ts
@@ -1,0 +1,5 @@
+import { version as vscodeVersion } from "vscode";
+// @ts-ignore
+import { name, version } from "../../package.json";
+
+export const userAgent: string = `${name}/${version} vscode/${vscodeVersion}`;


### PR DESCRIPTION
#31 Added user-agent header for requests to ATSD server from nodejs

Format:

```
axibasecharts-syntax/1.0.2 vscode/1.27.
```