### PR TITLE
Fix indent between setting/variable name and equals sign

### DIFF
--- a/server/src/test/indents.test.ts
+++ b/server/src/test/indents.test.ts
@@ -185,6 +185,48 @@ endfor`,
   endfor`,
             [], FormattingOptions.create(2, true),
         ),
+        new Test(
+            "Adds a space between setting name and equals sign",
+            `[configuration]
+  entity= cpu_busy`,
+            [
+                TextEdit.insert(Position.create(1, "  entity".length), " "),
+            ],
+            FormattingOptions.create(2, true),
+        ),
+        new Test(
+            "Removes an extra space between setting name and equals sign",
+            `[configuration]
+  entity  = cpu_busy`,
+            [
+                TextEdit.replace(Range.create(1, "  entity".length, 1, "  entity  ".length), " "),
+            ],
+            FormattingOptions.create(2, true),
+        ),
+        new Test(
+            "Adds a space between list name and equals sign",
+            `[configuration]
+  list entities= entity1, entity2`,
+            [
+                TextEdit.insert(Position.create(1, "  list entities".length), " "),
+            ],
+            FormattingOptions.create(2, true),
+        ),
+        new Test(
+            "Removes an extra space between list name and equals sign",
+            `[configuration]
+  list entities  = entity1, entity2`,
+            [
+                TextEdit.replace(Range.create(1, "  list entities".length, 1, "  list entities  ".length), " "),
+            ],
+            FormattingOptions.create(2, true),
+        ),
+        new Test(
+            "Does not affect equals signs in setting value",
+            `[configuration]
+  script = var hello = value()`,
+            [], FormattingOptions.create(2, true),
+        ),
     ];
 
     tests.forEach((test: Test) => { test.formatTest(); });

--- a/server/src/test/indents.test.ts
+++ b/server/src/test/indents.test.ts
@@ -224,7 +224,7 @@ endfor`,
         new Test(
             "Does not affect equals signs in setting value",
             `[configuration]
-  script = var hello = value()`,
+  script = var hello= value()`,
             [], FormattingOptions.create(2, true),
         ),
     ];


### PR DESCRIPTION
Adds a new formatting: 
* inserts a space between setting/variable name and equals sign if there are no any
* Removes extra spaces if there are more than one