### PR TITLE
Completion improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,7 @@
 			"args": ["--disable-extensions","--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/client/out/**/*.js"],
-			"preLaunchTask": "npm: watch:client"
+			"outFiles": ["${workspaceRoot}/client/out/**/*.js"]
 		},
 		{
 			"type": "node",

--- a/client/src/axibaseChartsProvider.ts
+++ b/client/src/axibaseChartsProvider.ts
@@ -38,7 +38,7 @@ export class AxibaseChartsProvider implements TextDocumentContentProvider {
     private url!: string;
 
     public constructor(details: IConnectionDetails, document: TextDocument,
-                       absolutePath: (path: string) => string) {
+        absolutePath: (path: string) => string) {
         if (document.languageId !== languageId) {
             throw new Error("Incorrect language");
         }
@@ -147,10 +147,10 @@ ${this.text.substr(match.index + match[0].length + 1)}`;
 	</style>
 	<script>
 	    window.previewOptions = ${JSON.stringify({
-            jsessionid: this.jsessionid,
-            text: this.text,
-            url: this.url,
-        })};
+                jsessionid: this.jsessionid,
+                text: this.text,
+                url: this.url,
+            })};
 	</script>
 	<script src="${this.resource("portal_init.js")}"></script>
 	<script src="${this.extensionPath("resources/js/config_init.js")}"></script>
@@ -171,7 +171,7 @@ ${this.text.substr(match.index + match[0].length + 1)}`;
     /**
      * Adds the ATSD URL to the import statements
      * For example, `import fred = fred.js` becomes
-     * `import fred = https://nur.axibase.com/portal/resource/scripts/fred.js`
+     * `import fred = https://example.com/portal/resource/scripts/fred.js`
      */
     private replaceImports(): void {
         if (!this.text) {

--- a/client/src/test/e2e/diagnostic.test.ts
+++ b/client/src/test/e2e/diagnostic.test.ts
@@ -19,7 +19,7 @@ suite("Should diagnostics", () => {
         await window.showTextDocument(document);
         await sleep(4000);
         const actualDiagnostic: Diagnostic[] = languages.getDiagnostics(docUri);
-        strictEqual(actualDiagnostic.length, 1, "Incorrect number of messages for file");
+        strictEqual(actualDiagnostic.length, 2, "Incorrect number of messages for file");
         await commands.executeCommand("workbench.action.closeActiveEditor");
     });
 

--- a/examples/source.config
+++ b/examples/source.config
@@ -1,51 +1,13 @@
 [configuration]
-	height-units = 1
+  height-units = 2
   width-units = 1
-  display-panels = true
-  expand-panels = all
-  server-aggregate = false
+  offset-right = 50
 
 [group]
+    type = 
+    display =
+    max-range = 100
 
-/*
-Controls at the top allow you to
-recompute aggregate statistics on-the-fly,
-without reloading the dataset.
+    format-axis =    
 
-To calculate aggregates on the server, set
-server-aggregate = true 
-*/
-  
-[widget]
-  type = chart
-  time-span = 6 hour
-  step-line = false
-  min-range = 0
-  max-range = 100
-  metric = cpu_busy
-  label-format = entity: statistic: period
-    
-list servers = nurswgvml006, 
-  nurswgvml007
-endlist
-    
-for server in servers
-[series]
-    entity = @{server}
-    data-type = forecast
-      
-[series]
-    entity = @{server}
-    statistic = avg
-    period = 10 minute      
-endfor
-
-for server in servers
-  [series]
-    entity = @{server}
-    if server == 'nurswgvml007'
-      color = red
-    elseif server == 'nurswgvml006'
-      color = yellow
-    endif
-endfor
+    list servers = nurswgvml010, nurswgvml007

--- a/examples/source.config
+++ b/examples/source.config
@@ -1,13 +1,51 @@
 [configuration]
-  height-units = 2
+	height-units = 1
   width-units = 1
-  offset-right = 50
+  display-panels = true
+  expand-panels = all
+  server-aggregate = false
 
 [group]
-    type = 
-    display =
-    max-range = 100
 
-    format-axis =    
+/*
+Controls at the top allow you to
+recompute aggregate statistics on-the-fly,
+without reloading the dataset.
 
-    list servers = nurswgvml010, nurswgvml007
+To calculate aggregates on the server, set
+server-aggregate = true 
+*/
+  
+[widget]
+  type = chart
+  time-span = 6 hour
+  step-line = false
+  min-range = 0
+  max-range = 100
+  metric = cpu_busy
+  label-format = entity: statistic: period
+    
+list servers = nurswgvml006, 
+  nurswgvml007
+endlist
+    
+for server in servers
+[series]
+    entity = @{server}
+    data-type = forecast
+      
+[series]
+    entity = @{server}
+    statistic = avg
+    period = 10 minute      
+endfor
+
+for server in servers
+  [series]
+    entity = @{server}
+    if server == 'nurswgvml007'
+      color = red
+    elseif server == 'nurswgvml006'
+      color = yellow
+    endif
+endfor

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "configurationDefaults": {
       "[axibasecharts]": {
         "editor.tabSize": 2,
-        "editor.insertSpaces": true
+        "editor.insertSpaces": true,
+        "editor.snippetSuggestions": "none"
       }
     },
     "languages": [

--- a/server/dictionary.json
+++ b/server/dictionary.json
@@ -764,7 +764,9 @@
             "enum": [
                 "blue",
                 "red",
-                "black"
+                "black",
+                "green",
+                "yellow"
             ]
         },
         {
@@ -842,6 +844,68 @@
             "displayName": "day-format",
             "type": "string",
             "example": "%y/%m/%d",
+            "possibleValues": [
+                {
+                    "value": "%a",
+                    "detail": "Three-letter abbreviated day name, for example: Sun, Mon, Tue, Wed, Thu, Fri, Sat."
+                },
+                {
+                    "value": "%aa",
+                    "detail": "Two-letter abbreviated day name, for example: Su, Mo, Tu, We, Th, Fr, Sa."
+                },
+                {
+                    "value": "%A",
+                    "detail": "Full day name."
+                },
+                {
+                    "value": "%b",
+                    "detail": "Abbreviated month name."
+                },
+                {
+                    "value": "%B",
+                    "detail": "Full month name."
+                },
+                {
+                    "value": "%d",
+                    "detail": "Zero-padded day of the month as a decimal number [01,31]."
+                },
+                {
+                    "value": "%e",
+                    "detail": "Space-padded day of the month as a decimal number [ 1,31]. Equivalent to %_d."
+                },
+                {
+                    "value": "%j",
+                    "detail": "Day of the year as a decimal number [001,366]."
+                },
+                {
+                    "value": "%m",
+                    "detail": "Month as a decimal number [01,12]."
+                },
+                {
+                    "value": "%U",
+                    "detail": "Week number of the year as a decimal number [00,53]. Sunday is the first day of the week."
+                },
+                {
+                    "value": "%w",
+                    "detail": "Weekday as a decimal number [0(Sunday),6]."
+                },
+                {
+                    "value": "%W",
+                    "detail": "Week number of the year as a decimal number [00,53]. Monday is the first day of the week."
+                },
+                {
+                    "value": "%x",
+                    "detail": "Date, as %m/%d/%Y."
+                },
+                {
+                    "value": "%y",
+                    "detail": "Year without century as a decimal number [00,99]."
+                },
+                {
+                    "value": "%Y",
+                    "detail": "Year with century as a decimal number."
+                }
+            ],
             "section": "widget"
         },
         {
@@ -2058,6 +2122,32 @@
             "displayName": "format",
             "type": "string",
             "example": "kilobytes",
+            "possibleValues": [
+                {
+                    "value": "bytes"
+                },
+                {
+                    "value": "kilobytes"
+                },
+                {
+                    "value": "megawatt"
+                },
+                {
+                    "value": "kilowatthour"
+                },
+                {
+                    "value": "hertz"
+                },
+                {
+                    "value": "kilojoule"
+                },
+                {
+                    "value": "million watt"
+                },
+                {
+                    "value": "thousands"
+                }
+            ],
             "section": "widget",
             "script": {
                 "returnValue": "string",
@@ -5230,7 +5320,10 @@
         {
             "displayName": "series",
             "widget": "graph",
-            "section": ["node", "link"],
+            "section": [
+                "node",
+                "link"
+            ],
             "type": "string",
             "example": "series-1"
         },
@@ -7666,7 +7759,63 @@
         {
             "displayName": "type",
             "type": "string",
-            "example": "chart"
+            "example": "chart",
+            "possibleValues": [
+                {
+                    "value": "chart",
+                    "detail": "Time Charts display series values\nat successive time intervals, showing one or more series, each assigned to the left or right value axis and scaled independently.\nTime Charts load data for\na specified time interval and update the chart with incremental values as new data is received."
+                },
+                {
+                    "value": "gauge",
+                    "detail": "Gauge Chart displays last series value on a gauge with colored threshold ranges. If the gauge widget contains multiple series, it displays the sum of the series values."
+                },
+                {
+                    "value": "treemap",
+                    "detail": "Treemap displays each series as a rectangle, sized according to the size setting and colored according to the magnitude of deviation of the series value from the threshold."
+                },
+                {
+                    "value": "bar",
+                    "detail": "Bar Charts group series into columns and displays them as horizontal or vertical bars."
+                },
+                {
+                    "value": "calendar",
+                    "detail": "The Calendar Chart displays deviation of aggregated series values for each calendar period from the specified threshold. Series values within each period are aggregated with a statistical function, avg by default, and the aggregated period value is then assigned a certain color which reflects the magnitude of the deviation."
+                },
+                {
+                    "value": "histogram",
+                    "detail": "Histogram charts visualize data distribution."
+                },
+                {
+                    "value": "box",
+                    "detail": "The Box Chart displays the minimum and maximum values, the median, and two percentiles in a given period of time for each series."
+                },
+                {
+                    "value": "pie",
+                    "detail": "Pie Chart illustrates numerical proportions between series values and their total value."
+                },
+                {
+                    "value": "graph",
+                    "detail": "The graph widget displays the topology and relationships of servers, virtual machines, and managers alongside corresponding status."
+                },
+                {
+                    "value": "text"
+                },
+                {
+                    "value": "page"
+                },
+                {
+                    "value": "console",
+                    "detail": "The Alert Console displays a continuously updated list of open alerts or messages in tabular format."
+                },
+                {
+                    "value": "table",
+                    "detail": "Use Streaming Table widget to display a table of metric values. By default, it contains four columns: entity, metric, time, and value."
+                },
+                {
+                    "value": "property",
+                    "detail": "The Property Table Widget displays properties collected for the entity in tabular format."
+                }
+            ]
         },
         {
             "displayName": "unscale",

--- a/server/dictionary.json
+++ b/server/dictionary.json
@@ -4973,8 +4973,8 @@
         },
         {
             "displayName": "refresh-interval",
-            "type": "integer",
-            "example": 120,
+            "type": "interval",
+            "example": "5 second",
             "section": "series"
         },
         {

--- a/server/dictionary.schema.json
+++ b/server/dictionary.schema.json
@@ -18,8 +18,23 @@
               {
                 "type": "string",
                 "enum": [
-                  "column", "configuration", "dropdown", "group", "keys", "link", "node", "option", "other", "placeholders",
-                  "properties", "property", "series", "tag", "tags", "threshold", "widget"
+                  "column",
+                  "configuration",
+                  "dropdown",
+                  "group",
+                  "keys",
+                  "link",
+                  "node",
+                  "option",
+                  "other",
+                  "placeholders",
+                  "properties",
+                  "property",
+                  "series",
+                  "tag",
+                  "tags",
+                  "threshold",
+                  "widget"
                 ]
               },
               {
@@ -29,8 +44,23 @@
                 "items": {
                   "type": "string",
                   "enum": [
-                    "column", "configuration", "dropdown", "group", "keys", "link", "node", "option", "other", "placeholders",
-                    "properties", "property", "series", "tag", "tags", "threshold", "widget"
+                    "column",
+                    "configuration",
+                    "dropdown",
+                    "group",
+                    "keys",
+                    "link",
+                    "node",
+                    "option",
+                    "other",
+                    "placeholders",
+                    "properties",
+                    "property",
+                    "series",
+                    "tag",
+                    "tags",
+                    "threshold",
+                    "widget"
                   ]
                 }
               }
@@ -44,16 +74,30 @@
             "type": "string",
             "description": "The type of the setting",
             "enum": [
-              "boolean", "string", "enum", "number", "interval", "date", "integer"
+              "boolean",
+              "string",
+              "enum",
+              "number",
+              "interval",
+              "date",
+              "integer"
             ]
           },
           "defaultValue": {
             "description": "Default setting value",
-            "type": ["string", "number", "boolean"]
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ]
           },
           "example": {
             "description": "Example value",
-            "type": ["string", "number", "boolean"]
+            "type": [
+              "string",
+              "number",
+              "boolean"
+            ]
           },
           "minValue": {
             "description": "[Optional] Minimal value constraint. Default is 'no constraint'",
@@ -77,8 +121,20 @@
             "description": "[Optional] Which widget accepts the setting. Default is 'all'",
             "type": "string",
             "enum": [
-              "gauge", "chart", "bar", "histogram", "box", "calendar", "treemap", "pie",
-              "graph", "text", "page", "console", "table", "property"
+              "gauge",
+              "chart",
+              "bar",
+              "histogram",
+              "box",
+              "calendar",
+              "treemap",
+              "pie",
+              "graph",
+              "text",
+              "page",
+              "console",
+              "table",
+              "property"
             ]
           },
           "excludes": {
@@ -100,6 +156,16 @@
             },
             "additionalProperties": false
           },
+          "possibleValues": {
+            "description": "[Optional] Unique objects containing values which can be assigned to the setting with 'string' type and descriptions for these values",
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "description": "Contains value and description fields"
+            }
+          },
           "script": {
             "description": "[Optional] Description of this script. Default is null",
             "type": "object",
@@ -115,7 +181,13 @@
                       "description": "The type of the inline JavaScript argument",
                       "type": "string",
                       "enum": [
-                        "array", "boolean", "integer", "number", "object", "string", "function"
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "object",
+                        "string",
+                        "function"
                       ]
                     },
                     "nullable": {
@@ -137,7 +209,15 @@
                             "type": "string",
                             "description": "The type of this argument",
                             "enum": [
-                              "array", "boolean", "integer", "number", "function", "string", "interval", "date", "object"
+                              "array",
+                              "boolean",
+                              "integer",
+                              "number",
+                              "function",
+                              "string",
+                              "interval",
+                              "date",
+                              "object"
                             ]
                           },
                           "name": {
@@ -150,7 +230,8 @@
                           }
                         },
                         "required": [
-                          "type", "name"
+                          "type",
+                          "name"
                         ]
                       },
                       "uniqueItems": true
@@ -162,7 +243,13 @@
                 "description": "The value returned by this script",
                 "type": "string",
                 "enum": [
-                  "boolean", "number", "string", "void", "integer", "interval", "date"
+                  "boolean",
+                  "number",
+                  "string",
+                  "void",
+                  "integer",
+                  "interval",
+                  "date"
                 ]
               }
             },
@@ -172,7 +259,9 @@
           }
         },
         "required": [
-          "displayName", "type", "example"
+          "displayName",
+          "type",
+          "example"
         ]
       },
       "minItems": 1,

--- a/server/src/completionProvider.ts
+++ b/server/src/completionProvider.ts
@@ -156,19 +156,23 @@ endif
                 }
                 if (setting.script) {
                     setting.script.fields.forEach(field => {
-                        if (field.args) {
-                            let requiredArgs: Field[] = field.args.filter(a => a.required);
-                            let optionalArgs: Field[] = field.args.filter(a => !a.required);
-                            let requiredArgsString: string = `${requiredArgs.map(field => field.name).join(", ")}`;
-                            scriptItems.push(this.fillCompletionItem(`${field.name}(${requiredArgsString})`));
-                            let args: string = "";
-                            for (let arg of optionalArgs) {
-                                args = `${args !== "" ? args + ", " : ""}${arg.name}`;
-                                scriptItems.push(this.fillCompletionItem(`${field.name}(${requiredArgsString !== "" ?
-                                    requiredArgsString + ", " : ""}${args})`));
+                        if (field.type === "function") {
+                            if (field.args) {
+                                let requiredArgs: Field[] = field.args.filter(a => a.required);
+                                let optionalArgs: Field[] = field.args.filter(a => !a.required);
+                                let requiredArgsString: string = `${requiredArgs.map(field => field.name).join(", ")}`;
+                                scriptItems.push(this.fillCompletionItem(`${field.name}(${requiredArgsString})`));
+                                let args: string = "";
+                                for (let arg of optionalArgs) {
+                                    args = `${args !== "" ? args + ", " : ""}${arg.name}`;
+                                    scriptItems.push(this.fillCompletionItem(`${field.name}(${requiredArgsString !== "" ?
+                                        requiredArgsString + ", " : ""}${args})`));
+                                }
+                            } else {
+                                scriptItems.push(this.fillCompletionItem(`${field.name}()`));
                             }
                         } else {
-                            scriptItems.push(this.fillCompletionItem(`${field.name}()`));
+                            scriptItems.push(this.fillCompletionItem(`${field.name}`, `Type: ${field.type}`));
                         }
                     });
                 }

--- a/server/src/completionProvider.ts
+++ b/server/src/completionProvider.ts
@@ -142,6 +142,9 @@ endif
      */
     private completeSetting(settingName: string): CompletionItem[] {
         let setting = getSetting(settingName);
+        if (!setting) {
+            return [];
+        }
         switch (setting.type) {
             case "string": {
                 let valueItems: CompletionItem[] = [];

--- a/server/src/javaScriptValidator.ts
+++ b/server/src/javaScriptValidator.ts
@@ -5,7 +5,7 @@ import { TextRange } from "./textRange";
 import { JavaScriptChecksQueue } from "./javaScriptChecksQueue";
 import { CheckPriority } from "./checkPriority";
 
-export class JsDomCaller {
+export class JavaScriptValidator {
 
     private currentLineNumber: number = 0;
     private importCounter: number = 0;
@@ -74,6 +74,7 @@ export class JsDomCaller {
         if (line === undefined) {
             throw new Error("this.currentLineNumber points to nowhere");
         }
+
         return line;
     }
 
@@ -111,9 +112,24 @@ export class JsDomCaller {
                     this.processOptions();
                     continue;
                 }
+                this.match = /^\s*csv\s*(\w*)\s*/.exec(line);
+                if (this.match) {
+                    const statement: TextRange = new TextRange(`var ${this.match[1]}=[];`,
+                        Range.create(
+                            this.currentLineNumber, this.match.index,
+                            this.currentLineNumber, this.match.index + this.match.length,
+                        ), CheckPriority.High
+                    );
+                    this.queue.queue(statement);
+                    continue;
+                }
             }
             this.match = /^\s*script/.exec(line);
             if (this.match) {
+                /**
+                 * passes through script lines neither validateAll is true or false
+                 * to prevent var checks inside the script setting
+                 */
                 this.processScript(validateAll);
                 continue;
             }

--- a/server/src/possibleValue.ts
+++ b/server/src/possibleValue.ts
@@ -1,0 +1,13 @@
+export class PossibleValue {
+
+    public readonly value: string;
+    /**
+     * Description of value
+     */
+    public readonly detail: string = "";
+
+    public constructor(value: string, detail?: string) {
+        this.value = value;
+        this.detail = detail;
+    }
+}

--- a/server/src/resources.ts
+++ b/server/src/resources.ts
@@ -68,27 +68,54 @@ function createSettingsMap(): Map<string, Setting> {
 
 export const settingsMap: Map<string, Setting> = createSettingsMap();
 
+interface SectionRequirements {
+    settings?: Setting[][];
+    sections?: string[][];
+}
+
 /**
  * Map of required settings for each section and their "aliases".
  * For instance, `series` requires `entity`, but `entities` is also allowed.
  * Additionally, `series` requires `metric`, but `table` with `attribute` is also ok
  */
-export const requiredSectionSettingsMap: Map<string, Setting[][]> = new Map([
-    ["series", [
-        [
-            settingsMap.get("entity")!, settingsMap.get("value")!,
-            settingsMap.get("entities")!, settingsMap.get("entitygroup")!,
-            settingsMap.get("entityexpression")!,
+export const requiredSectionSettingsMap = new Map<string, SectionRequirements>([
+    ["configuration", {
+        sections: [
+            ["group"],
         ],
-        [
-            settingsMap.get("metric")!, settingsMap.get("value")!,
-            settingsMap.get("table")!, settingsMap.get("attribute")!,
+    }],
+    ["series", {
+        settings: [
+            [
+                settingsMap.get("entity")!, settingsMap.get("value")!,
+                settingsMap.get("entities")!, settingsMap.get("entitygroup")!,
+                settingsMap.get("entityexpression")!,
+            ],
+            [
+                settingsMap.get("metric")!, settingsMap.get("value")!,
+                settingsMap.get("table")!, settingsMap.get("attribute")!,
+            ],
         ],
-    ]],
-    ["widget", [[settingsMap.get("type")!],
-    ]],
-    ["dropdown", [[settingsMap.get("onchange")!, settingsMap.get("changefield")!],
-    ]],
+    }],
+    ["group", {
+        sections: [
+            ["widget"],
+        ],
+    }],
+    ["widget", {
+        sections: [
+            ["series"],
+            ["column"],
+        ],
+        settings: [
+            [settingsMap.get("type")!],
+        ],
+    }],
+    ["dropdown", {
+        settings: [
+            [settingsMap.get("onchange")!, settingsMap.get("changefield")!],
+        ],
+    }],
 ]);
 
 /**
@@ -120,10 +147,26 @@ export function getParents(section: string): string[] {
     return parents;
 }
 
-/**
- * Array of all possible sections
- */
-export const possibleSections: string[] = [
-    "column", "configuration", "dropdown", "group", "keys", "link", "node", "option", "other", "placeholders",
-    "properties", "property", "series", "tag", "tags", "threshold", "widget",
-];
+export const sectionDepthMap: {[section: string]: number} = {
+    "configuration": 0,
+
+    "group": 1,
+
+    "widget": 2,
+
+    "column": 3,
+    "dropdown": 3,
+    "link": 3,
+    "node": 3,
+    "other": 3,
+    "placeholders": 3,
+    "property": 3,
+    "series": 3,
+    "threshold": 3,
+
+    "keys": 4,
+    "option": 4,
+    "properties": 4,
+    "tag": 4,
+    "tags": 4,
+};

--- a/server/src/sectionStack.ts
+++ b/server/src/sectionStack.ts
@@ -1,0 +1,174 @@
+import { TextRange } from "./textRange";
+import { sectionDepthMap, requiredSectionSettingsMap } from "./resources";
+import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver";
+
+interface DependencyResolveInfo {
+    resolvedCount: number;
+    unresolved: string[];
+}
+
+class SectionStackNode {
+    public readonly dependencies: DependencyResolveInfo[] = [];
+
+    public constructor(public range: TextRange) {
+        const deps = requiredSectionSettingsMap.get(this.name);
+        if (deps && deps.sections) {
+            for (const option of deps.sections) {
+                this.dependencies.push({
+                    resolvedCount: 0,
+                    unresolved: option.slice(),
+                });
+            }
+        }
+    }
+
+    /**
+     * Remove section from dependency list for every dependency option
+     * @param name name of incoming section
+     */
+    public resolveDependency(name: string): void {
+        for (const option of this.dependencies) {
+            const index: number = option.unresolved.indexOf(name);
+            if (index >= 0) {
+                option.resolvedCount++;
+                option.unresolved.splice(index, 1);
+            }
+        }
+    }
+
+    /**
+     * True if dependencies for any dependency option are resolved
+     */
+    public get dependenciesResolved(): boolean {
+        if (this.dependencies.length === 0) {
+            return true;
+        }
+
+        return this.dependencies.some((deps) => deps.unresolved.length === 0);
+    }
+
+    /**
+     * A name of underlying section
+     */
+    public get name(): string {
+        return this.range.text;
+    }
+
+    /**
+     * A list of unresolved dependencies for section. If several options for
+     * dependency list provisioned, return best of them. The best option is
+     * an option with max number of resolved dependencies and min length of
+     * unresolved.
+     */
+    public get unresolved(): string[] {
+        if (this.dependencies.length === 0) {
+            return [];
+        }
+
+        const bestDependencyOption: DependencyResolveInfo = this.dependencies
+            .reduce((best, dep) => {
+                if (dep.resolvedCount > best.resolvedCount) {
+                    return dep;
+                }
+                if (dep.unresolved.length < best.unresolved.length) {
+                    return dep;
+                }
+
+                return best;
+            });
+
+        return bestDependencyOption.unresolved;
+    }
+}
+
+// tslint:disable-next-line:max-classes-per-file
+export class SectionStack {
+    private stack: SectionStackNode[] = [];
+
+    public insertSection(section: TextRange): Diagnostic | null {
+        const sectionName: string = section.text;
+        let depth: number = 0;
+        try {
+            depth = this.checkAndGetDepth(sectionName);
+        } catch (err) {
+            return this.createErrorDignostic(section, (err as Error).message);
+        }
+
+        let error: Diagnostic | null = null;
+        if (depth < this.stack.length) {
+            if (depth === 0) {
+                // We are attempting to declare [configuration] twice
+                return this.createErrorDignostic(section, `Unexpected section [${sectionName}].`);
+            }
+
+            // Pop stack, check dependencies of popped resolved
+            error = this.checkDependenciesResolved(depth);
+            this.stack.splice(depth, this.stack.length - depth);
+        }
+
+        for (const entry of this.stack) {
+            entry.resolveDependency(sectionName);
+        }
+
+        this.stack.push(new SectionStackNode(section));
+
+        return error;
+    }
+
+    public finalize(): Diagnostic {
+        return this.checkDependenciesResolved(0);
+    }
+
+    private createErrorDignostic(section: TextRange, message: string): Diagnostic {
+        return Diagnostic.create(
+            section.range,
+            message,
+            DiagnosticSeverity.Error,
+        );
+    }
+
+    private checkDependenciesResolved(startIndex: number): Diagnostic | null {
+        const stack: SectionStackNode[] = this.stack;
+
+        for (let i = stack.length; i > startIndex;) {
+            const section: SectionStackNode = stack[--i];
+            if (!section.dependenciesResolved) {
+                let unresolved = section.unresolved.map(s => `[${s}]`);
+                let message: string;
+
+                if (unresolved.length > 1) {
+                    message = `Required sections ${unresolved.join(", ")} are not declared.`;
+                } else {
+                    message = `Required section ${unresolved.join(", ")} is not declared.`;
+                }
+
+                return this.createErrorDignostic(section.range, message);
+            }
+        }
+
+        return null;
+    }
+
+    private checkAndGetDepth(section: string): number {
+        const expectedDepth: number = this.stack.length;
+        const actualDepth: number = sectionDepthMap[section];
+
+        if (actualDepth == null) {
+            throw new Error(`Unknown section [${section}].`);
+        } else if (actualDepth > expectedDepth) {
+            let errorMessage = `Unexpected section [${section}]. `;
+            let expectedSections: string[] = Object.entries(sectionDepthMap)
+                .filter(([, depth]) => depth === expectedDepth)
+                .map(([key, ]) => `[${key}]`);
+
+            if (expectedSections.length > 1) {
+                errorMessage += `Expected one of ${expectedSections.join(", ")}.`;
+            } else {
+                errorMessage += `Expected ${expectedSections[0]}.`;
+            }
+            throw new Error(errorMessage);
+        }
+
+        return actualDepth;
+    }
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,7 +7,7 @@ import {
 import { CompletionProvider } from "./completionProvider";
 import { Formatter } from "./formatter";
 import { HoverProvider } from "./hoverProvider";
-import { JsDomCaller } from "./jsDomCaller";
+import { JavaScriptValidator } from "./javaScriptValidator";
 import { Validator } from "./validator";
 
 // Create a connection for the server. The connection uses Node"s IPC as a transport.
@@ -88,16 +88,13 @@ const validateTextDocument: (textDocument: TextDocument) => Promise<void> =
         const settings: IServerSettings = await getDocumentSettings(textDocument.uri);
         const text: string = textDocument.getText();
         const validator: Validator = new Validator(text);
-        const jsDomCaller: JsDomCaller = new JsDomCaller(text);
+        const jsValidator: JavaScriptValidator = new JavaScriptValidator(text);
         const diagnostics: Diagnostic[] = validator.lineByLine();
-
-        jsDomCaller.validate(settings.validateFunctions).forEach((element: Diagnostic) => {
-            diagnostics.push(element);
-        });
+        const jsDiagnostics: Diagnostic[] = jsValidator.validate(settings.validateFunctions || true);
 
         // Send the computed diagnostics to VSCode.
         // connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });
-        connection.sendNotification("charts-diagnostic", [textDocument.uri, diagnostics]);
+        connection.sendNotification("charts-diagnostic", [textDocument.uri, diagnostics.concat(jsDiagnostics)]);
     };
 
 connection.onDidChangeConfiguration((change: DidChangeConfigurationParams) => {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -134,9 +134,7 @@ connection.onCompletion((params: CompletionParams): CompletionItem[] => {
     return completionProvider.getCompletionItems();
 });
 
-connection.onCompletionResolve((item: CompletionItem): CompletionItem => {
-    return item;
-});
+connection.onCompletionResolve((item: CompletionItem): CompletionItem => item);
 
 // Make the text document manager listen on the connection
 documents.listen(connection);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -134,7 +134,9 @@ connection.onCompletion((params: CompletionParams): CompletionItem[] => {
     return completionProvider.getCompletionItems();
 });
 
-connection.onCompletionResolve((item: CompletionItem): CompletionItem => item);
+connection.onCompletionResolve((item: CompletionItem): CompletionItem => {
+    return item;
+});
 
 // Make the text document manager listen on the connection
 documents.listen(connection);

--- a/server/src/setting.ts
+++ b/server/src/setting.ts
@@ -32,17 +32,13 @@ export class Setting {
         "false", "no", "null", "none", "0", "off", "true", "yes", "on", "1",
     ];
 
-    private static _intervalUnits: string[] = [
+    public static readonly intervalUnits: string[] = [
         "nanosecond", "millisecond", "second", "minute", "hour", "day", "week", "month", "quarter", "year",
     ];
 
-    public static get intervalUnits(): string[] {
-        return Setting._intervalUnits;
-    }
-
     private static readonly booleanRegExp: RegExp = new RegExp(`^(?:${Setting.booleanKeywords.join("|")})$`);
 
-    private static _calendarKeywords: string[] = [
+    public static readonly calendarKeywords: string[] = [
         "current_day", "current_hour", "current_minute", "current_month", "current_quarter", "current_week",
         "current_year", "first_day", "first_vacation_day", "first_working_day", "friday", "last_vacation_day",
         "last_working_day", "monday", "next_day", "next_hour", "next_minute", "next_month", "next_quarter",
@@ -50,10 +46,6 @@ export class Setting {
         "previous_minute", "previous_month", "previous_quarter", "previous_vacation_day", "previous_week",
         "previous_working_day", "previous_year", "saturday", "sunday", "thursday", "tuesday", "wednesday",
     ];
-
-    public static get calendarKeywords(): string[] {
-        return Setting._calendarKeywords;
-    }
 
     private static readonly calendarRegExp: RegExp = new RegExp(
         // current_day
@@ -137,7 +129,7 @@ export class Setting {
 
     /**
      * Create an instance of setting with matching overrides applied.
-     * If no override can be applied returns this insatnce.
+     * If no override can be applied returns this instanse.
      * @param scope Configuration scope where setting exist
      */
     public applyScope(scope: SettingScope): Setting {

--- a/server/src/test/completionProvider.test.ts
+++ b/server/src/test/completionProvider.test.ts
@@ -1,0 +1,30 @@
+import { Test } from "./test";
+import { Position } from "vscode-languageserver";
+
+
+suite("CompletionProvider tests", () => {
+    [
+        new Test(
+            "Correct: completion using possibleValues",
+            `type = `,
+            ["chart", "gauge", "treemap", "bar", "calendar", "histogram", "box", "pie", "graph", "text", "page", "console", "table",
+                "property"],
+            undefined,
+            Position.create(0, "type = ".length),
+        ),
+        new Test(
+            "Correct: completion using example",
+            `url = `,
+            ["http://atsd_hostname:port"],
+            undefined,
+            Position.create(0, "url = ".length),
+        ),
+        new Test(
+            "Correct: completion using example and script",
+            `alert-style = `,
+            ["stroke: red; stroke-width: 2", "alert"],
+            undefined,
+            Position.create(0, "alert-style = ".length),
+        )
+    ].forEach((test: Test): void => test.completionTest());
+});

--- a/server/src/test/csv.test.ts
+++ b/server/src/test/csv.test.ts
@@ -70,9 +70,17 @@ endcsv`,
         new Test(
             "Correct csv with escaped whitespaces and commas",
             `csv countries = name, value1, value2
-   Russia, "6,5", 63
-   USA, 63, "6 3"
-endcsv`,
+                Russia, "6,5", 63
+                USA, 63, "6 3"
+            endcsv`,
+            [],
+        ),
+        new Test(
+            "Correct csv with not escaped whitespaces",
+            `csv index =
+                president,inauguration
+                Gerald Ford, 1974
+            endcsv`,
             [],
         ),
     ];

--- a/server/src/test/js.script.test.ts
+++ b/server/src/test/js.script.test.ts
@@ -22,7 +22,7 @@ endscript`,
         ),
         new Test(
             "Correct function declaration and call",
-            `script 
+            `script
             window.numberToDate = function (n) {
             var di = Math.round(n*1)+"";
             return new Date(di.substring(0,4), di.substring(4,6), di.substring(6,8), di.substring(8,10), di.substring(10,12), di.substring(12,14));
@@ -40,6 +40,25 @@ endscript`,
                return utc.substring(0, 4) + utc.substring(5, 7) + utc.substring(8, 10) + utc.substring(11, 13) + utc.substring(14, 16) + utc.substring(17, 19);
             };
           endscript`,
+            [],
+        ),
+        new Test(
+            "Correct csv reference",
+            `csv index =
+            president,inauguration
+            GeraldFord, 1974
+          endcsv
+          
+          script
+            window.indexMap = (function () {
+            var map = {};
+            var idx = @{JSON.stringify(index)};
+            for (var i = 0; i < idx.length; i++) {
+              map[idx[i].president] = idx[i].inauguration;
+              }
+              return map;
+              })()
+            endscript`,
             [],
         ),
         new Test(

--- a/server/src/test/sections.test.ts
+++ b/server/src/test/sections.test.ts
@@ -1,0 +1,92 @@
+import * as assert from "assert";
+import { Diagnostic, DiagnosticSeverity, Position } from "vscode-languageserver";
+import { SectionStack } from "../sectionStack";
+import { TextRange } from "../textRange";
+
+suite("SectionStack tests", () => {
+    let stack!: SectionStack;
+
+    setup(() => {
+        stack = new SectionStack();
+    });
+
+    test("Inserts configuration section successfully", () => {
+        let error = stack.insertSection(textRange("configuration"));
+        assert.strictEqual(error, null);
+    });
+
+    test("Inserts configuration, group, widget and section successfully", () => {
+        let error: Diagnostic | null;
+        error = stack.insertSection(textRange("configuration"));
+        assert.strictEqual(error, null);
+        error = stack.insertSection(textRange("group", 1));
+        assert.strictEqual(error, null);
+        error = stack.insertSection(textRange("widget", 2));
+        assert.strictEqual(error, null);
+        error = stack.insertSection(textRange("series", 3));
+        assert.strictEqual(error, null);
+        error = stack.finalize();
+        assert.strictEqual(error, null);
+    });
+
+    test("Rises error if wrong section is inserted", () => {
+        stack.insertSection(textRange("configuration"));
+        const error = stack.insertSection(textRange("widget", 1));
+        assert.deepStrictEqual(error, Diagnostic.create(
+            textRange("widget", 1).range,
+            "Unexpected section [widget]. Expected [group].",
+            DiagnosticSeverity.Error
+        ));
+    });
+
+    test("Rises error if section has unresolved dependencies", () => {
+        stack.insertSection(textRange("configuration"));
+        const error = stack.finalize();
+        assert.deepStrictEqual(error, Diagnostic.create(
+            textRange("configuration").range,
+            "Required section [group] is not declared.",
+            DiagnosticSeverity.Error
+        ));
+    });
+
+    test("Rises error if second section has unresolved dependencies", () => {
+        stack.insertSection(textRange("configuration", 0));
+        stack.insertSection(textRange("group", 1));
+        stack.insertSection(textRange("widget", 2));
+        stack.insertSection(textRange("group", 3));
+        const error = stack.finalize();
+        assert.deepStrictEqual(error, Diagnostic.create(
+            textRange("group", 3).range,
+            "Required section [widget] is not declared.",
+            DiagnosticSeverity.Error
+        ));
+    });
+
+    test("Rises error if first section has unresolved dependencies", () => {
+        stack.insertSection(textRange("configuration", 0));
+        stack.insertSection(textRange("group", 1));
+        const error = stack.insertSection(textRange("group", 2));
+        assert.deepStrictEqual(error, Diagnostic.create(
+            textRange("group", 1).range,
+            "Required section [widget] is not declared.",
+            DiagnosticSeverity.Error
+        ));
+    });
+
+    test("Rises error on attempt to insert unknown section", () => {
+        const error = stack.insertSection(textRange("bad"));
+        assert.deepStrictEqual(error, Diagnostic.create(
+            textRange("bad").range,
+            "Unknown section [bad].",
+            DiagnosticSeverity.Error
+        ));
+    });
+
+    function textRange(text: string, line: number = 0): TextRange {
+        return new TextRange(text, {
+            start: Position.create(line, 1),
+            end: Position.create(line, text.length),
+        });
+    }
+
+})

--- a/server/src/test/spelling.test.ts
+++ b/server/src/test/spelling.test.ts
@@ -19,24 +19,6 @@ suite("Spelling checks", () => {
             ],
         ),
         new Test(
-            "section eries",
-            `[eries]
-	starttime = 2018`,
-            [createDiagnostic(
-                Range.create(Position.create(0, "[".length), Position.create(0, "[eries".length)),
-                unknownToken("eries"),
-            )],
-        ),
-        new Test(
-            "section starttime",
-            `[starttime]
-	starttime = 2018`,
-            [createDiagnostic(
-                Range.create(Position.create(0, "[".length), Position.create(0, "[starttime".length)),
-                unknownToken("starttime"),
-            )],
-        ),
-        new Test(
             "tags ignored",
             `[tags]
 	startime = 2018`,
@@ -50,13 +32,10 @@ suite("Spelling checks", () => {
 	startime = 2018`,
             [
                 createDiagnostic(
-                    Range.create(Position.create(2, "[".length), Position.create(2, "[starttime".length)),
-                    unknownToken("starttime"),
-                ),
-                createDiagnostic(
                     Range.create(Position.create(3, "	".length), Position.create(3, " ".length + "startime".length)),
                     unknownToken("startime"),
-                )],
+                )
+            ],
         ),
         new Test(
             "tags ignoring finished with whitespace",

--- a/server/src/test/test.ts
+++ b/server/src/test/test.ts
@@ -1,18 +1,18 @@
 import * as assert from "assert";
 import { Diagnostic, FormattingOptions, Hover, Position, TextDocument, TextEdit } from "vscode-languageserver";
+import { CompletionProvider } from "../completionProvider";
 import { Formatter } from "../formatter";
 import { HoverProvider } from "../hoverProvider";
 import { JavaScriptValidator } from "../javaScriptValidator";
 import { SectionStack } from "../sectionStack";
 import { TextRange } from "../textRange";
 import { Validator } from "../validator";
-import { CompletionProvider } from "../completionProvider";
 
 /**
  * Stub section validator to allow incomplete configs in tests
  */
 // tslint:disable-next-line:no-object-literal-type-assertion
-const sectionStackStub: SectionStack  = {
+const sectionStackStub: SectionStack = {
     insertSection(_section: TextRange): Diagnostic | null {
         return null;
     },
@@ -96,7 +96,7 @@ export class Test {
     }
 
     /**
-     * Tests JsDomCaller (JavaScript statements, including var)
+     * Tests JavaScriptValidator (JavaScript statements, including var)
      */
     public jsValidationTest(): void {
         test((this.name), () => {
@@ -109,10 +109,9 @@ export class Test {
      */
     public completionTest(): void {
         test((this.name), () => {
-            assert.deepStrictEqual(new CompletionProvider(this.document, this.position).getCompletionItems().map(i => {
-                return i.insertText;
-            }),
-                this.expected);
+            const cp: CompletionProvider = new CompletionProvider(this.document, this.position);
+            const current: string[] = cp.getCompletionItems().map(i => i.insertText);
+            assert.deepStrictEqual(current, this.expected);
         });
     }
 }

--- a/server/src/test/test.ts
+++ b/server/src/test/test.ts
@@ -6,6 +6,7 @@ import { JavaScriptValidator } from "../javaScriptValidator";
 import { SectionStack } from "../sectionStack";
 import { TextRange } from "../textRange";
 import { Validator } from "../validator";
+import { CompletionProvider } from "../completionProvider";
 
 /**
  * Stub section validator to allow incomplete configs in tests
@@ -28,7 +29,7 @@ export class Test {
     /**
      * The expected result of the target function
      */
-    private readonly expected: Diagnostic[] | TextEdit[] | Hover;
+    private readonly expected: Diagnostic[] | TextEdit[] | Hover | string[];
     /**
      * The name of the test. Displayed in tests list after the execution
      */
@@ -50,7 +51,7 @@ export class Test {
     public constructor(
         name: string,
         text: string,
-        expected: Diagnostic[] | TextEdit[] | Hover,
+        expected: Diagnostic[] | TextEdit[] | Hover | string[],
         options?: FormattingOptions,
         position?: Position,
     ) {
@@ -100,6 +101,18 @@ export class Test {
     public jsValidationTest(): void {
         test((this.name), () => {
             assert.deepStrictEqual(new JavaScriptValidator(this.text).validate(true), this.expected);
+        });
+    }
+
+    /**
+     * Tests CompletionProvider
+     */
+    public completionTest(): void {
+        test((this.name), () => {
+            assert.deepStrictEqual(new CompletionProvider(this.document, this.position).getCompletionItems().map(i => {
+                return i.insertText;
+            }),
+                this.expected);
         });
     }
 }

--- a/server/src/test/test.ts
+++ b/server/src/test/test.ts
@@ -3,7 +3,7 @@ import { Diagnostic, FormattingOptions, Hover, Position, TextDocument, TextEdit 
 import { Formatter } from "../formatter";
 import { HoverProvider } from "../hoverProvider";
 import { Validator } from "../validator";
-import { JsDomCaller } from "../jsDomCaller";
+import { JavaScriptValidator } from "../javaScriptValidator";
 
 /**
  * Contains a test case and executes the test
@@ -81,7 +81,7 @@ export class Test {
      */
     public jsValidationTest(): void {
         test((this.name), () => {
-            assert.deepStrictEqual(new JsDomCaller(this.text).validate(true), this.expected);
+            assert.deepStrictEqual(new JavaScriptValidator(this.text).validate(true), this.expected);
         });
     }
 }

--- a/server/src/test/test.ts
+++ b/server/src/test/test.ts
@@ -2,8 +2,24 @@ import * as assert from "assert";
 import { Diagnostic, FormattingOptions, Hover, Position, TextDocument, TextEdit } from "vscode-languageserver";
 import { Formatter } from "../formatter";
 import { HoverProvider } from "../hoverProvider";
-import { Validator } from "../validator";
 import { JavaScriptValidator } from "../javaScriptValidator";
+import { SectionStack } from "../sectionStack";
+import { TextRange } from "../textRange";
+import { Validator } from "../validator";
+
+/**
+ * Stub section validator to allow incomplete configs in tests
+ */
+// tslint:disable-next-line:no-object-literal-type-assertion
+const sectionStackStub: SectionStack  = {
+    insertSection(_section: TextRange): Diagnostic | null {
+        return null;
+    },
+
+    finalize(): Diagnostic | null {
+        return null;
+    }
+} as SectionStack;
 
 /**
  * Contains a test case and executes the test
@@ -63,7 +79,9 @@ export class Test {
      */
     public validationTest(): void {
         test((this.name), () => {
-            assert.deepStrictEqual(new Validator(this.text).lineByLine(), this.expected);
+            let validator = new Validator(this.text);
+            Object.assign(validator, { sectionStack: sectionStackStub });
+            assert.deepStrictEqual(validator.lineByLine(), this.expected);
         });
     }
 

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -58,7 +58,7 @@ export function countCsvColumns(line: string): number {
     if (line.length === 0) {
         return 0;
     }
-    const regex: RegExp = /(['"]).+\1|[^, \t]+/g;
+    const regex: RegExp = /(['"]).+\1|(\w)[^,"']+/g;
     let counter: number = 0;
     while (regex.exec(line) !== null) {
         counter++;


### PR DESCRIPTION
Resolves #116 

Examples of setting completion:
![selection_102](https://user-images.githubusercontent.com/20650874/46493803-f7af5280-c819-11e8-9194-7bc4086f6e5d.png)

![selection_103](https://user-images.githubusercontent.com/20650874/46493814-fb42d980-c819-11e8-9b41-8d57be95f2a4.png)

![selection_104](https://user-images.githubusercontent.com/20650874/46493823-00078d80-c81a-11e8-8c3c-437a5b10ded7.png)

![selection_101](https://user-images.githubusercontent.com/20650874/46493839-072e9b80-c81a-11e8-8658-05fb365d4717.png)

![screenscast_20181004_202528](https://user-images.githubusercontent.com/20650874/46493847-0c8be600-c81a-11e8-960f-e6b5ae221904.gif)

Regex checks that there is no `=` before the current position, if so, snippets are enabled, otherwise `possibleValues/example/script.fields` (declared in `dictionary.json`) are suggested.