### PR TITLE
`expand-panels` contains erroneous options and flags legitimate settings.

### DIFF
--- a/server/descriptions.md
+++ b/server/descriptions.md
@@ -387,7 +387,7 @@ Double-click modifies `expand` setting interactively.
   
 ## expandpanels  
   
-Display control panels in the top left or right corners in Time and Bar charts.  
+Display control panels in the top left or right corners in Time chart.  
   
 ## expandtags  
   

--- a/server/dictionary.json
+++ b/server/dictionary.json
@@ -729,7 +729,7 @@
             "override": {
                 "[widget == 'console']": {
                     "enum": ["terminal"]
-                    
+
                 },
                 "[widget == 'box']": {
                     "enum": ["metro"]
@@ -1979,14 +1979,44 @@
             "displayName": "expand-panels",
             "type": "enum",
             "example": "all",
-            "defaultValue": "hover",
-            "enum": [
-                "all",
-                "hover",
-                "true",
-                "false"
-            ],
-            "section": "widget"
+            "defaultValue": "compact",
+            "enum": [],
+            "section": "widget",
+            "override": {
+              "[widget == 'chart']": {
+                "enum": [
+                  "true",
+                  "all",
+                  "default",
+                  "auto",
+                  "compact",
+                  "false",
+                  "none"
+                ]
+              },
+              "[widget == 'bar']": {
+                "enum": [
+                  "true",
+                  "all",
+                  "default",
+                  "auto",
+                  "compact",
+                  "false",
+                  "none"
+                ]
+              },
+              "[section == 'configuration']": {
+                "enum": [
+                  "true",
+                  "all",
+                  "default",
+                  "auto",
+                  "compact",
+                  "false",
+                  "none"
+                ]
+              }
+            }
         },
         {
             "displayName": "expand-tags",

--- a/server/dictionary.json
+++ b/server/dictionary.json
@@ -1994,17 +1994,6 @@
                   "none"
                 ]
               },
-              "[widget == 'bar']": {
-                "enum": [
-                  "true",
-                  "all",
-                  "default",
-                  "auto",
-                  "compact",
-                  "false",
-                  "none"
-                ]
-              },
               "[section == 'configuration']": {
                 "enum": [
                   "true",

--- a/server/src/setting.ts
+++ b/server/src/setting.ts
@@ -146,7 +146,6 @@ export class Setting {
     /**
      * Checks the type of the setting and creates a corresponding diagnostic
      * @param value value which is assigned to the setting
-     * @param widget widget where the setting is declared (none if no widget is found)
      * @param range where the error should be displayed
      * @param name name of the setting which is used by user
      */
@@ -192,7 +191,10 @@ export class Setting {
                 const index: number = this.enum.findIndex((option: string): boolean =>
                     new RegExp(`^${option}$`, "i").test(value),
                 );
-                if (index < 0) {
+                // Empty enum means that the setting is not allowed
+                if (this.enum.length === 0) {
+                    result = createDiagnostic(range, `${name} setting is not allowed here.`);
+                } else if (index < 0) {
                     const enumList: string = this.enum.join(";\n")
                         .replace(/percentile\(.+/, "percentile_{num};");
                     result = createDiagnostic(range, `${name} must be one of:\n${enumList}`);

--- a/server/src/test/setting.test.ts
+++ b/server/src/test/setting.test.ts
@@ -1,0 +1,87 @@
+import { deepStrictEqual } from "assert";
+import { DiagnosticSeverity, Position, Range } from "vscode-languageserver";
+import { createDiagnostic } from "../util";
+import { Validator } from "../validator";
+
+suite("Validator for expand-panels setting", () => {
+    const possibleValues = ["all", "true", "compact", "default", "auto", "none", "false"];
+    const incorrectValues = ["fals", "no", "notcompact"];
+
+    possibleValues.forEach(settingValue => {
+        test(`should not raise diagnostic messages for correct value ${settingValue} in configuration section`, () => {
+            const config = `[configuration]
+            entity = a
+            metric = a
+            expand-panels=${settingValue}
+            [group]
+              [widget]
+                type = chart
+                [series]`;
+            const validator = new Validator(config);
+            deepStrictEqual(validator.lineByLine(), [],
+                `Validator should not raise error for settings value ${settingValue}.
+Configuration: ${config}`);
+        });
+    });
+
+    possibleValues.forEach(settingValue => {
+        test(`should not raise diagnostic messages for correct value ${settingValue} in widget section`, () => {
+            const config = `[configuration]
+                entity = a
+                metric = a
+            [group]
+            [widget]
+        type = chart
+        expand-panels = ${settingValue}
+        [series]`;
+            const validator = new Validator(config);
+            deepStrictEqual(validator.lineByLine(), [],
+                `Validator should not raise error for settings value ${settingValue}.
+Configuration: ${config}`);
+        });
+    });
+
+    incorrectValues.forEach(settingValue => {
+        test(`should raise message about incorrect value ${settingValue} for valid configuration`, () => {
+            const config = `[configuration]
+                entity = a
+                metric = a
+            [group]
+            [widget]
+        type = chart
+        expand-panels = ${settingValue}
+        [series]`;
+            const validator = new Validator(config);
+            const actualDiagnostics = validator.lineByLine();
+            const expectedDiagnostic = createDiagnostic(
+                Range.create(Position.create(6, 8), Position.create(6, 21)),
+                "expand-panels must be one of:\ntrue;\nall;\ndefault;\nauto;\ncompact;\nfalse;\nnone",
+                DiagnosticSeverity.Error
+            );
+            deepStrictEqual(actualDiagnostics, [expectedDiagnostic],
+                `Validator should not raise error for settings value ${settingValue}.
+Configuration: ${config}`);
+        });
+    });
+
+    test("should not allow the setting for not chart or bar widget", () => {
+        const config = `[configuration]
+                entity = a
+                metric = a
+            [group]
+            [widget]
+        type = tree
+        expand-panels = compact
+        [series]`;
+        const validator = new Validator(config);
+        const actualDiagnostics = validator.lineByLine();
+        const expectedDiagnostic = createDiagnostic(
+            Range.create(Position.create(6, 8), Position.create(6, 21)),
+            "expand-panels setting is not allowed here.",
+            DiagnosticSeverity.Error
+        );
+        deepStrictEqual(actualDiagnostics, [expectedDiagnostic],
+            `Validator should inform if setting is not allowed for this type of widget.
+Configuration: ${config}`);
+    });
+});

--- a/server/src/test/setting.test.ts
+++ b/server/src/test/setting.test.ts
@@ -64,13 +64,13 @@ Configuration: ${config}`);
         });
     });
 
-    test("should not allow the setting for not chart or bar widget", () => {
+    test("should not allow the setting for not chart widget", () => {
         const config = `[configuration]
                 entity = a
                 metric = a
             [group]
             [widget]
-        type = tree
+        type = bar
         expand-panels = compact
         [series]`;
         const validator = new Validator(config);


### PR DESCRIPTION
#170 

### Conclusion

The setting affects only on a widget with type `chart`.

For a bar chart, we can't control panels mode with the setting.

In the case of `chart` type, there are three available behaviors that apply when `display-panels` is set to `true` or `hover`

| Setting Value | Behavior |
| --- | --- |
| `all`,`true` | Full mode of panels |
| `auto`, `default`, `compact` | Compact and **default** mode of panels |
| `none`, `false` | panels don't display |

**Default** behavior: Compact mode.

Demo portal: https://apps.axibase.com/chartlab/f0dcb2c0/4/


