### PR TITLE
Fixed completion and `on-change` issues

### DIFF
--- a/server/dictionary.json
+++ b/server/dictionary.json
@@ -4763,7 +4763,7 @@
             "displayName": "on-change",
             "section": "dropdown",
             "type": "string",
-            "multiLine": true,
+            "multiLine": false,
             "example": "widget.post.queries[0].type = this.value; widget.reload();",
             "script": {
                 "returnValue": "void",
@@ -6862,6 +6862,11 @@
             "maxValue": 1,
             "defaultValue": 0.9,
             "example": 0.8
+        },
+        {
+            "displayName": "text",
+            "type": "string",
+            "example": "Option 3"
         },
         {
             "displayName": "thresholds",

--- a/server/src/completionProvider.ts
+++ b/server/src/completionProvider.ts
@@ -25,7 +25,8 @@ export class CompletionProvider {
     public constructor(textDocument: TextDocument, position: Position) {
         const text: string = textDocument.getText().substr(0, textDocument.offsetAt(position));
         this.text = deleteScripts(deleteComments(text));
-        this.currentLine = this.text.split("\n")[position.line];
+        let textList = this.text.split("\n");
+        this.currentLine = textList[textList.length - 1];
     }
 
     /**

--- a/server/src/javaScriptValidator.ts
+++ b/server/src/javaScriptValidator.ts
@@ -22,7 +22,7 @@ export class JavaScriptValidator {
 
     /**
      * Evaluates all found JavaScript statements in this.document
-     * @param validateAll if `false`, validates var only 
+     * @param validateAll if `false`, validates var only
      * @returns diagnostic for each invalid statement
      */
     public validate(validateAll: boolean): Diagnostic[] {
@@ -83,7 +83,7 @@ export class JavaScriptValidator {
     }
 
     /**
-     * Calls corresponding processor for all found JavaScript statements 
+     * Calls corresponding processor for all found JavaScript statements
      * in this.document to prepare diagnostic if required
      * @param validateAll if `false`, validates "var" only
      */


### PR DESCRIPTION
Fixed:
1. incorrect completion if config contains comments
2. 
![selection_102](https://user-images.githubusercontent.com/20650874/46755869-d8f40480-ccce-11e8-902c-ef09e689984a.png)

Checked  manually, `on-change` isn't multiline.
