### PR TITLE
Show warning on deprecated settings usage

### DIFF
--- a/server/dictionary.json
+++ b/server/dictionary.json
@@ -7125,7 +7125,6 @@
             "section": "widget",
             "example": false,
             "defaultValue": true,
-            "deprecated": "",
             "override": {
                 "[widget == 'chart']": {
                     "deprecated": "This setting is deprecated in timechart. Use `mode = stack` instead"

--- a/server/dictionary.json
+++ b/server/dictionary.json
@@ -7124,7 +7124,13 @@
             "type": "boolean",
             "section": "widget",
             "example": false,
-            "defaultValue": true
+            "defaultValue": true,
+            "deprecated": "",
+            "override": {
+                "[widget == 'chart']": {
+                    "deprecated": "This setting is deprecated in timechart. Use `mode = stack` instead"
+                }
+            }
         },
         {
             "displayName": "start-time",

--- a/server/dictionary.schema.json
+++ b/server/dictionary.schema.json
@@ -208,6 +208,10 @@
               "description": "A setting, which is excluded"
             }
           },
+          "deprecated": {
+            "description": "[Optinal] Warning message to show if setting is deprecated",
+            "type": "string"
+          },
           "override": {
             "patternProperties": {
               "^\\[.+\\]$": {

--- a/server/src/defaultSetting.ts
+++ b/server/src/defaultSetting.ts
@@ -77,7 +77,7 @@ export class DefaultSetting {
     /**
      * Warning text to show if setting is deprecated
      */
-    public readonly deprecated: string = "";
+    public readonly deprecated: string | null = null;
     /**
      * Holds the description of the setting if it is a script
      */

--- a/server/src/defaultSetting.ts
+++ b/server/src/defaultSetting.ts
@@ -77,7 +77,7 @@ export class DefaultSetting {
     /**
      * Warning text to show if setting is deprecated
      */
-    public readonly deprecated: string | null = null;
+    public readonly deprecated?: string;
     /**
      * Holds the description of the setting if it is a script
      */

--- a/server/src/defaultSetting.ts
+++ b/server/src/defaultSetting.ts
@@ -75,6 +75,10 @@ export class DefaultSetting {
      */
     public readonly name: string = "";
     /**
+     * Warning text to show if setting is deprecated
+     */
+    public readonly deprecated: string = "";
+    /**
      * Holds the description of the setting if it is a script
      */
     public readonly script?: Script;

--- a/server/src/test/deprecatedSettings.test.ts
+++ b/server/src/test/deprecatedSettings.test.ts
@@ -1,0 +1,41 @@
+import { deepStrictEqual } from "assert";
+import { DiagnosticSeverity, Position, Range } from "vscode-languageserver";
+import { createDiagnostic } from "../util";
+import { Validator } from "../validator";
+
+suite("Warn about deprecated setting", () => {
+    test("Shows warning message for deprecated setting in relevant widget type", () => {
+        const config = `[configuration]
+            [group]
+            [widget]
+                type = chart
+                stack = false
+                metric = a
+                [column]
+                    [series]
+                    entity = b`;
+        const validator = new Validator(config);
+        const actualDiagnostics = validator.lineByLine();
+        const expectedDiagnostic = createDiagnostic(
+            Range.create(Position.create(4, 16), Position.create(4, 21)),
+            "This setting is deprecated in timechart. Use `mode = stack` instead",
+            DiagnosticSeverity.Warning
+        );
+        deepStrictEqual(actualDiagnostics, [expectedDiagnostic]);
+    });
+
+    test("Doesn't show warning message for deprecated setting in irrelevant widget type", () => {
+        const config = `[configuration]
+            [group]
+            [widget]
+                type = bar
+                stack = false
+                metric = a
+                [column]
+                    [series]
+                    entity = b`;
+        const validator = new Validator(config);
+        const actualDiagnostics = validator.lineByLine();
+        deepStrictEqual(actualDiagnostics, []);
+    });
+});

--- a/server/src/validator.ts
+++ b/server/src/validator.ts
@@ -1006,6 +1006,17 @@ export class Validator {
         }
         this.addSettingValue(setting);
 
+        /**
+         * Show hint if setting is deprecated
+         */
+        if (setting.deprecated) {
+            this.result.push(createDiagnostic(
+                setting.textRange,
+                setting.deprecated,
+                DiagnosticSeverity.Warning
+            ));
+        }
+
         if (!this.isAllowedInSection(setting)) {
             this.result.push(createDiagnostic(
                 setting.textRange,


### PR DESCRIPTION
Closes #306 

Now warning message is shown when deprecated setting is used with specific chart type.

![image](https://user-images.githubusercontent.com/15448200/56954552-b7157e80-6b47-11e9-9597-27c4530df66a.png)

Config example:

```
[configuration]
[group]
[widget]
  type = chart
  stack = false
  metric = a

  [column]
    [series]
      entity = b
```