### PR TITLE
Make `statistics = detail` valid value

### DIFF
--- a/server/dictionary.json
+++ b/server/dictionary.json
@@ -7187,6 +7187,7 @@
             "section": "series",
             "enum": [
                 "count",
+                "detail",
                 "min",
                 "max",
                 "sum",


### PR DESCRIPTION
Closes #321

Added `detail` to `statistics` possible values. Now `statistics` is equivalent  to `statistic`