### PR TITLE
Don't add extra space in `>=` and `<=` relations

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -10,3 +10,13 @@ export const calendarKeywords: string[] = [
     "previous_minute", "previous_month", "previous_quarter", "previous_vacation_day", "previous_week",
     "previous_working_day", "previous_year", "saturday", "sunday", "thursday", "tuesday", "wednesday",
 ];
+
+export const relations: string[] = [
+    "!=",
+    "==",
+    "=",
+    ">=",
+    "<=",
+    ">",
+    "<"
+];

--- a/server/src/formatter.ts
+++ b/server/src/formatter.ts
@@ -1,4 +1,5 @@
 import { FormattingOptions, Range, TextEdit } from "vscode-languageserver";
+import { relations } from "./constants";
 import { BLOCK_SQL_END, BLOCK_SQL_START } from "./keywordHandler";
 import { isNestedToPrevious, sectionDepthMap } from "./resources";
 import { TextRange } from "./textRange";
@@ -91,7 +92,7 @@ export class Formatter {
                 this.increaseIndent();
                 continue;
             } else {
-                this.checkEquals();
+                this.checkSign();
             }
             if (TextRange.isClosing(line)) {
                 const stackHead: number | undefined = this.keywordsLevels.pop();
@@ -112,11 +113,11 @@ export class Formatter {
     }
 
     /**
-     * Checks how many spaces are between equals sign and setting name
+     * Checks how many spaces are between the sign and setting name
      */
-    private checkEquals(): void {
+    private checkSign(): void {
         const line: string = this.getCurrentLine();
-        const regexp: RegExp = /(^\s*.+?)(\s*?)(!=|==|=)(\s*)/;
+        const regexp: RegExp = new RegExp(`(^\\s*.+?)(\\s*?)(${relations.join("|")})(\\s*)`);
         const match: RegExpExecArray | null = regexp.exec(line);
         if (match === null) {
             return;

--- a/server/src/formatter.ts
+++ b/server/src/formatter.ts
@@ -1,8 +1,8 @@
 import { FormattingOptions, Range, TextEdit } from "vscode-languageserver";
-import { RELATIONS } from "./constants";
 import { isNestedToPrevious, sectionDepthMap } from "./resources";
 import { TextRange } from "./textRange";
 import { createRange, isEmpty } from "./util";
+import { RELATIONS_REGEXP } from "./regExpressions";
 
 interface Section {
     indent?: string;
@@ -116,8 +116,7 @@ export class Formatter {
      */
     private checkSign(): void {
         const line: string = this.getCurrentLine();
-        const regexp: RegExp = new RegExp(`(^\\s*.+?)(\\s*?)(${RELATIONS.join("|")})(\\s*)`);
-        const match: RegExpExecArray | null = regexp.exec(line);
+        const match: RegExpExecArray | null = RELATIONS_REGEXP.exec(line);
         if (match === null) {
             return;
         }

--- a/server/src/regExpressions.ts
+++ b/server/src/regExpressions.ts
@@ -1,4 +1,4 @@
-import { BOOLEAN_KEYWORDS, INTERVAL_UNITS } from "./constants";
+import { BOOLEAN_KEYWORDS, INTERVAL_UNITS, RELATIONS } from "./constants";
 
 /** Regular expressions for CSV syntax checking */
 
@@ -67,3 +67,6 @@ export const NUMBER_REGEXP: RegExp = /^(?:\-|\+)?(?:\.\d+|\d+(?:\.\d+)?)$/;
 
 // ${server}, ${example}
 export const CALCULATED_REGEXP: RegExp = /[@$]\{.+\}/;
+
+// =, ==, !=, >=, <=, >, <
+export const RELATIONS_REGEXP: RegExp =  new RegExp(`(^\\s*.+?)(\\s*?)(${RELATIONS.join("|")})(\\s*)`);

--- a/server/src/test/indents.test.ts
+++ b/server/src/test/indents.test.ts
@@ -471,26 +471,38 @@ suite("Formatting indents tests: >=, <=, >, <", () => {
     const text = `if a > b`;
     const options: FormattingOptions = FormattingOptions.create(2, true);
     const expected: TextEdit[] = [];
-    deepStrictEqual(new Formatter(text, options).lineByLine(), expected);
+    const formatter = new Formatter(text, options);
+    const actual = formatter.lineByLine();
+    deepStrictEqual(actual, expected);
   });
+  
   test("Correct <", () => {
     const text = `if a < b`;
     const options: FormattingOptions = FormattingOptions.create(2, true);
     const expected: TextEdit[] = [];
-    deepStrictEqual(new Formatter(text, options).lineByLine(), expected);
+    const formatter = new Formatter(text, options);
+    const actual = formatter.lineByLine();
+    deepStrictEqual(actual, expected);
   });
+
   test("Correct >=", () => {
     const text = `if a >= b`;
     const options: FormattingOptions = FormattingOptions.create(2, true);
     const expected: TextEdit[] = [];
-    deepStrictEqual(new Formatter(text, options).lineByLine(), expected);
+    const formatter = new Formatter(text, options);
+    const actual = formatter.lineByLine();
+    deepStrictEqual(actual, expected);
   });
+
   test("Correct <=", () => {
     const text = `if a <= b`;
     const options: FormattingOptions = FormattingOptions.create(2, true);
     const expected: TextEdit[] = [];
-    deepStrictEqual(new Formatter(text, options).lineByLine(), expected);
+    const formatter = new Formatter(text, options);
+    const actual = formatter.lineByLine();
+    deepStrictEqual(actual, expected);
   });
+
   test("Incorrect > (extra spaces before)", () => {
     const text = `if a   > b`;
     const options: FormattingOptions = FormattingOptions.create(2, true);
@@ -500,8 +512,11 @@ suite("Formatting indents tests: >=, <=, >, <", () => {
         Position.create(0, "if a   ".length)), " "
       )
     ];
-    deepStrictEqual(new Formatter(text, options).lineByLine(), expected);
+    const formatter = new Formatter(text, options);
+    const actual = formatter.lineByLine();
+    deepStrictEqual(actual, expected);
   });
+
   test("Incorrect <= (extra spaces after)", () => {
     const text = `if a <=   b`;
     const options: FormattingOptions = FormattingOptions.create(2, true);
@@ -511,6 +526,8 @@ suite("Formatting indents tests: >=, <=, >, <", () => {
         Position.create(0, "if a <=   ".length)), " "
       )
     ];
-    deepStrictEqual(new Formatter(text, options).lineByLine(), expected);
+    const formatter = new Formatter(text, options);
+    const actual = formatter.lineByLine();
+    deepStrictEqual(actual, expected);
   });
 });

--- a/server/src/test/indents.test.ts
+++ b/server/src/test/indents.test.ts
@@ -456,11 +456,48 @@ suite("Formatting indents tests: !=, ==, = ", () => {
       "Incorrect =",
       `type=bar`, [TextEdit.replace(Range.create(
         Position.create(0, "type".length), Position.create(0, "type".length)), " "),
-        TextEdit.replace(Range.create(
-          Position.create(0, "type=".length), Position.create(0, "type=".length)), " ")
+      TextEdit.replace(Range.create(
+        Position.create(0, "type=".length), Position.create(0, "type=".length)), " ")
       ],
       FormattingOptions.create(2, true),
     )];
-  tests.forEach((test: Test) => { test.formatTest(); }
-  );
+  tests.forEach((test: Test) => { test.formatTest(); });
+});
+
+suite("Formatting indents tests: >=, <=, >, <", () => {
+  const tests: Test[] = [
+    new Test(
+      "Correct >",
+      `if a > b`, [], FormattingOptions.create(2, true),
+    ),
+    new Test(
+      "Correct <",
+      `if a < b`, [], FormattingOptions.create(2, true),
+    ),
+    new Test(
+      "Correct >=",
+      `if a >= b`, [], FormattingOptions.create(2, true),
+    ), new Test(
+      "Correct <=",
+      `if a <= b`, [], FormattingOptions.create(2, true),
+    ), new Test(
+      "Incorrect > (extra spaces before)",
+      `if a   > b`, [
+        TextEdit.replace(Range.create(
+          Position.create(0, "if a".length),
+          Position.create(0, "if a   ".length)), " "
+        )
+      ],
+      FormattingOptions.create(2, true),
+    ), new Test(
+      "Incorrect <= (extra spaces after)",
+      `if a <=   b`, [
+        TextEdit.replace(Range.create(
+          Position.create(0, "if a <=".length),
+          Position.create(0, "if a <=   ".length)), " "
+        )
+      ],
+      FormattingOptions.create(2, true),
+    )];
+  tests.forEach((test: Test) => { test.formatTest(); });
 });

--- a/server/src/test/indents.test.ts
+++ b/server/src/test/indents.test.ts
@@ -1,5 +1,7 @@
 import { FormattingOptions, Position, Range, TextEdit } from "vscode-languageserver";
 import { Test } from "./test";
+import { deepStrictEqual } from "assert";
+import { Formatter } from "../formatter";
 
 suite("Formatting indents tests: sections and settings", () => {
   const tests: Test[] = [
@@ -465,39 +467,50 @@ suite("Formatting indents tests: !=, ==, = ", () => {
 });
 
 suite("Formatting indents tests: >=, <=, >, <", () => {
-  const tests: Test[] = [
-    new Test(
-      "Correct >",
-      `if a > b`, [], FormattingOptions.create(2, true),
-    ),
-    new Test(
-      "Correct <",
-      `if a < b`, [], FormattingOptions.create(2, true),
-    ),
-    new Test(
-      "Correct >=",
-      `if a >= b`, [], FormattingOptions.create(2, true),
-    ), new Test(
-      "Correct <=",
-      `if a <= b`, [], FormattingOptions.create(2, true),
-    ), new Test(
-      "Incorrect > (extra spaces before)",
-      `if a   > b`, [
-        TextEdit.replace(Range.create(
-          Position.create(0, "if a".length),
-          Position.create(0, "if a   ".length)), " "
-        )
-      ],
-      FormattingOptions.create(2, true),
-    ), new Test(
-      "Incorrect <= (extra spaces after)",
-      `if a <=   b`, [
-        TextEdit.replace(Range.create(
-          Position.create(0, "if a <=".length),
-          Position.create(0, "if a <=   ".length)), " "
-        )
-      ],
-      FormattingOptions.create(2, true),
-    )];
-  tests.forEach((test: Test) => { test.formatTest(); });
+  test("Correct >", () => {
+    const text = `if a > b`;
+    const options: FormattingOptions = FormattingOptions.create(2, true);
+    const expected: TextEdit[] = [];
+    deepStrictEqual(new Formatter(text, options).lineByLine(), expected);
+  });
+  test("Correct <", () => {
+    const text = `if a < b`;
+    const options: FormattingOptions = FormattingOptions.create(2, true);
+    const expected: TextEdit[] = [];
+    deepStrictEqual(new Formatter(text, options).lineByLine(), expected);
+  });
+  test("Correct >=", () => {
+    const text = `if a >= b`;
+    const options: FormattingOptions = FormattingOptions.create(2, true);
+    const expected: TextEdit[] = [];
+    deepStrictEqual(new Formatter(text, options).lineByLine(), expected);
+  });
+  test("Correct <=", () => {
+    const text = `if a <= b`;
+    const options: FormattingOptions = FormattingOptions.create(2, true);
+    const expected: TextEdit[] = [];
+    deepStrictEqual(new Formatter(text, options).lineByLine(), expected);
+  });
+  test("Incorrect > (extra spaces before)", () => {
+    const text = `if a   > b`;
+    const options: FormattingOptions = FormattingOptions.create(2, true);
+    const expected: TextEdit[] = [
+      TextEdit.replace(Range.create(
+        Position.create(0, "if a".length),
+        Position.create(0, "if a   ".length)), " "
+      )
+    ];
+    deepStrictEqual(new Formatter(text, options).lineByLine(), expected);
+  });
+  test("Incorrect <= (extra spaces after)", () => {
+    const text = `if a <=   b`;
+    const options: FormattingOptions = FormattingOptions.create(2, true);
+    const expected: TextEdit[] = [
+      TextEdit.replace(Range.create(
+        Position.create(0, "if a <=".length),
+        Position.create(0, "if a <=   ".length)), " "
+      )
+    ];
+    deepStrictEqual(new Formatter(text, options).lineByLine(), expected);
+  });
 });


### PR DESCRIPTION
Closes #347 

Formatter was adding extra space because was interpreting only `=` from `>=`. Added more mathematical relations to the dictionary.