### PR TITLE
JavaScript formatting between `script` tags

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
 	"publisher": "Axibase",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/kirmanak/Axibase-Charts-Syntax"
+		"url": "https://github.com/axibase/axibase-charts-vscode"
 	},
 	"engines": {
 		"vscode": "^1.25.0"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4,6 +4,24 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@types/escodegen": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@types/escodegen/-/escodegen-0.0.6.tgz",
+			"integrity": "sha1-UjCpznluBCzabwhtvxnyLqMwZZw="
+		},
+		"@types/esprima": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/esprima/-/esprima-4.0.2.tgz",
+			"integrity": "sha512-DKqdyuy7Go7ir6iKhZ0jUvgt/h9Q5zb9xS+fLeeXD2QSHv8gC6TimgujBBGfw8dHrpx4+u2HlMv7pkYOOfuUqg==",
+			"requires": {
+				"@types/estree": "*"
+			}
+		},
+		"@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+		},
 		"@types/events": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
@@ -291,12 +309,19 @@
 				"esutils": "^2.0.2",
 				"optionator": "^0.8.1",
 				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+				}
 			}
 		},
 		"esprima": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-			"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"estraverse": {
 			"version": "4.2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,10 @@
 		"url": "https://github.com/kirmanak/Axibase-Charts-Syntax"
 	},
 	"dependencies": {
+		"@types/escodegen": "0.0.6",
+		"@types/esprima": "^4.0.2",
+		"escodegen": "^1.11.1",
+		"esprima": "^4.0.1",
 		"jsdom": "^12.0.0",
 		"vscode-languageserver": "^5.1.0"
 	},

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/kirmanak/Axibase-Charts-Syntax"
+		"url": "https://github.com/axibase/axibase-charts-vscode"
 	},
 	"dependencies": {
 		"@types/escodegen": "0.0.6",

--- a/server/src/formatter.ts
+++ b/server/src/formatter.ts
@@ -78,9 +78,9 @@ export class Formatter {
      * @returns array of text edits to properly format document
      */
     public lineByLine(): TextEdit[] {
-        this.currentLine = -1;
+        this.currentLine = 0;
 
-        for (let line = this.nextLine(); line !== void 0; line = this.nextLine()) {
+        for (let line = this.getLine(this.currentLine); line !== void 0; line = this.nextLine()) {
             if (isEmpty(line)) {
                 if (this.currentSection.name === "tags" && this.previousSection.name !== "widget") {
                     Object.assign(this.currentSection, this.previousSection);

--- a/server/src/formatter.ts
+++ b/server/src/formatter.ts
@@ -129,6 +129,10 @@ export class Formatter {
             buffer.push(line);
             line = this.nextLine();
         }
+
+        if (!buffer.length) {
+            return;
+        }
         const content = buffer.join("\n");
 
         // Parse and format JavaScript

--- a/server/src/formatter.ts
+++ b/server/src/formatter.ts
@@ -93,7 +93,9 @@ export class Formatter {
                 this.increaseIndent();
                 continue;
             } else if (BLOCK_SCRIPT_START.test(line)) {
+                this.checkIndent();
                 this.formatScript();
+                this.checkIndent();
                 continue;
             } else {
                 this.checkSign();
@@ -135,7 +137,7 @@ export class Formatter {
         const formattedCode = generate(parsedCode, {
             format: {
                 indent: {
-                    base: this.currentIndent.length,
+                    base: (this.currentIndent.length / this.options.tabSize) + 1,
                     style: " ".repeat(this.options.tabSize)
                 }
             }

--- a/server/src/formatter.ts
+++ b/server/src/formatter.ts
@@ -293,7 +293,6 @@ export class Formatter {
             if (line === undefined) {
                 return undefined;
             }
-
             this.removeExtraSpaces(line);
             this.lastLine = line;
             this.lastLineNumber = i;

--- a/server/src/formatter.ts
+++ b/server/src/formatter.ts
@@ -120,8 +120,8 @@ export class Formatter {
      * Formats JavaScript content inside script tags
      */
     private formatScript(): void {
-        const startLine = this.currentLine;
         let line = this.nextLine();
+        const startLine = this.currentLine;
 
         // Get content between script tags
         const buffer = [];

--- a/server/src/formatter.ts
+++ b/server/src/formatter.ts
@@ -123,13 +123,13 @@ export class Formatter {
      */
     private formatScript(): void {
         let content = ``;
-        let line = this.getLine(++this.currentLine);
+        let line = this.getLine(++this.currentLine, false);
         const startLine = this.currentLine;
 
         // Get content between script tags
         while (line !== undefined && !BLOCK_SCRIPT_END.test(line)) {
             content += `${line}\n`;
-            line = this.getLine(++this.currentLine);
+            line = this.getLine(++this.currentLine, false);
         }
 
         // Parse and format JavaScript
@@ -293,13 +293,17 @@ export class Formatter {
      * @param i the required line number
      * @returns the required line
      */
-    private getLine(i: number): string | undefined {
+    private getLine(i: number, makeLowerCase: boolean = true): string | undefined {
         if (!this.lastLine || this.lastLineNumber !== i) {
             let line: string | undefined = this.lines[i];
             if (line === undefined) {
                 return undefined;
             }
-            line = line.toLowerCase();
+
+            if (makeLowerCase) {
+                line = line.toLowerCase();
+            }
+
             this.removeExtraSpaces(line);
             this.lastLine = line;
             this.lastLineNumber = i;

--- a/server/src/formatter.ts
+++ b/server/src/formatter.ts
@@ -78,8 +78,6 @@ export class Formatter {
      * @returns array of text edits to properly format document
      */
     public lineByLine(): TextEdit[] {
-        this.currentLine = 0;
-
         for (let line = this.getLine(this.currentLine); line !== void 0; line = this.nextLine()) {
             if (isEmpty(line)) {
                 if (this.currentSection.name === "tags" && this.previousSection.name !== "widget") {

--- a/server/src/formatter.ts
+++ b/server/src/formatter.ts
@@ -122,15 +122,16 @@ export class Formatter {
      * Formats JavaScript content inside script tags
      */
     private formatScript(): void {
-        let content = ``;
-        let line = this.getLine(++this.currentLine, false);
+        let line = this.getLine(++this.currentLine);
         const startLine = this.currentLine;
 
         // Get content between script tags
+        const buffer = [];
         while (line !== undefined && !BLOCK_SCRIPT_END.test(line)) {
-            content += `${line}\n`;
-            line = this.getLine(++this.currentLine, false);
+            buffer.push(line);
+            line = this.getLine(++this.currentLine);
         }
+        const content = buffer.join("\n");
 
         // Parse and format JavaScript
         const parsedCode = parseScript(content);
@@ -142,11 +143,6 @@ export class Formatter {
                 }
             }
         });
-
-        // If formatted code is the same as original, no need to make edit
-        if (formattedCode === content) {
-            return;
-        }
 
         const endLine = this.currentLine - 1;
         const endCharacter = this.getLine(endLine).length;
@@ -289,19 +285,15 @@ export class Formatter {
 
     /**
      * Caches last returned line in this.lastLineNumber
-     * To prevent several calls toLowerCase and removeExtraSpaces
+     * To prevent several calls of removeExtraSpaces
      * @param i the required line number
      * @returns the required line
      */
-    private getLine(i: number, makeLowerCase: boolean = true): string | undefined {
+    private getLine(i: number): string | undefined {
         if (!this.lastLine || this.lastLineNumber !== i) {
             let line: string | undefined = this.lines[i];
             if (line === undefined) {
                 return undefined;
-            }
-
-            if (makeLowerCase) {
-                line = line.toLowerCase();
             }
 
             this.removeExtraSpaces(line);

--- a/server/src/formatter.ts
+++ b/server/src/formatter.ts
@@ -79,8 +79,8 @@ export class Formatter {
      */
     public lineByLine(): TextEdit[] {
         this.currentLine = -1;
-        while (this.currentLine < this.lines.length - 1) {
-            let line = this.getLine(++this.currentLine);
+
+        for (let line = this.nextLine(); line !== void 0; line = this.nextLine()) {
             if (isEmpty(line)) {
                 if (this.currentSection.name === "tags" && this.previousSection.name !== "widget") {
                     Object.assign(this.currentSection, this.previousSection);
@@ -122,14 +122,14 @@ export class Formatter {
      * Formats JavaScript content inside script tags
      */
     private formatScript(): void {
-        let line = this.getLine(++this.currentLine);
         const startLine = this.currentLine;
+        let line = this.nextLine();
 
         // Get content between script tags
         const buffer = [];
         while (line !== undefined && !BLOCK_SCRIPT_END.test(line)) {
             buffer.push(line);
-            line = this.getLine(++this.currentLine);
+            line = this.nextLine();
         }
         const content = buffer.join("\n");
 
@@ -302,6 +302,13 @@ export class Formatter {
         }
 
         return this.lastLine;
+    }
+
+    /**
+     * Gets next line of text document
+     */
+    private nextLine(): string | undefined {
+        return this.getLine(++this.currentLine);
     }
 
     /**

--- a/server/src/regExpressions.ts
+++ b/server/src/regExpressions.ts
@@ -44,7 +44,7 @@ export const ONE_LINE_SCRIPT = /^\s*script\s*=.*$/m;
 export const BLOCK_SCRIPT_START_WITHOUT_LF = /(^\s*)script\s*\S/;
 
 // script
-export const BLOCK_SCRIPT_START = /script(?!([\s\S]*=))/;
+export const BLOCK_SCRIPT_START = /(?:^\s*)script(?!([\s\S]*=))/;
 
 // endscript
 export const BLOCK_SCRIPT_END = /^\s*endscript\s*$/;

--- a/server/src/test/scriptFormatting.test.ts
+++ b/server/src/test/scriptFormatting.test.ts
@@ -7,14 +7,14 @@ suite("JavasScript code formatting", () => {
         const text = `script
         window.userFunction = function () {
         return Math.round(value / 10) * 10;
-        }
-      endscript`;
+        };
+endscript`;
         const options: FormattingOptions = FormattingOptions.create(2, true);
         const expected: TextEdit[] = [
             TextEdit.replace(Range.create(
                 Position.create(1, 0),
-                Position.create(3, 9)),
-                "window.userfunction = function () {\n  return math.round(value / 10) * 10;\n};"
+                Position.create(3, 10)),
+                "  window.userfunction = function () {\n    return math.round(value / 10) * 10;\n  };"
             )
         ];
         const formatter = new Formatter(text, options);
@@ -24,14 +24,14 @@ suite("JavasScript code formatting", () => {
 
     test("Code written in one line", () => {
         const text = `script
-        window.userfunction = function () {return math.round(value / 10) * 10;};
-        endscript`;
+        window.userFunction = function () {return Math.round(value / 10) * 10;};
+endscript`;
         const options: FormattingOptions = FormattingOptions.create(2, true);
         const expected: TextEdit[] = [
             TextEdit.replace(Range.create(
                 Position.create(1, 0),
                 Position.create(1, 80)),
-                "window.userfunction = function () {\n  return math.round(value / 10) * 10;\n};"
+                "  window.userfunction = function () {\n    return math.round(value / 10) * 10;\n  };"
             )
         ];
         const formatter = new Formatter(text, options);
@@ -40,17 +40,18 @@ suite("JavasScript code formatting", () => {
     });
 
     test("Unformatted code inside script tag in [configuration]", () => {
-        const text = `[configuration]
-        script
-          window.userFunction = function () {
-          return Math.round(value / 10) * 10;
-          }
-        endscript`;
+        const text = `
+[configuration]
+  script
+    window.userfunction = function () {
+    return math.round(value / 10) * 10;
+    };
+  endscript`;
         const options: FormattingOptions = FormattingOptions.create(2, true);
         const expected: TextEdit[] = [
             TextEdit.replace(Range.create(
-                Position.create(2, 0),
-                Position.create(4, 11)),
+                Position.create(3, 0),
+                Position.create(5, 6)),
                 "    window.userfunction = function () {\n      return math.round(value / 10) * 10;\n    };"
             )
         ];
@@ -60,17 +61,18 @@ suite("JavasScript code formatting", () => {
     });
 
     test("Unformatted code inside script tag in [group]", () => {
-        const text = `[group]
-        script
-          window.userFunction = function () {
-          return Math.round(value / 10) * 10;
-          }
-        endscript`;
+        const text = `
+[group]
+  script
+    window.userFunction = function () {
+    return Math.round(value / 10) * 10;
+    };
+  endscript`;
         const options: FormattingOptions = FormattingOptions.create(2, true);
         const expected: TextEdit[] = [
             TextEdit.replace(Range.create(
-                Position.create(2, 0),
-                Position.create(4, 11)),
+                Position.create(3, 0),
+                Position.create(5, 6)),
                 "    window.userfunction = function () {\n      return math.round(value / 10) * 10;\n    };"
             )
         ];

--- a/server/src/test/scriptFormatting.test.ts
+++ b/server/src/test/scriptFormatting.test.ts
@@ -14,7 +14,7 @@ endscript`;
             TextEdit.replace(Range.create(
                 Position.create(1, 0),
                 Position.create(3, 10)),
-                "  window.userfunction = function () {\n    return math.round(value / 10) * 10;\n  };"
+                "  window.userFunction = function () {\n    return Math.round(value / 10) * 10;\n  };"
             )
         ];
         const formatter = new Formatter(text, options);
@@ -31,7 +31,7 @@ endscript`;
             TextEdit.replace(Range.create(
                 Position.create(1, 0),
                 Position.create(1, 80)),
-                "  window.userfunction = function () {\n    return math.round(value / 10) * 10;\n  };"
+                "  window.userFunction = function () {\n    return Math.round(value / 10) * 10;\n  };"
             )
         ];
         const formatter = new Formatter(text, options);
@@ -43,8 +43,8 @@ endscript`;
         const text = `
 [configuration]
   script
-    window.userfunction = function () {
-    return math.round(value / 10) * 10;
+    window.userFunction = function () {
+    return Math.round(value / 10) * 10;
     };
   endscript`;
         const options: FormattingOptions = FormattingOptions.create(2, true);
@@ -52,7 +52,7 @@ endscript`;
             TextEdit.replace(Range.create(
                 Position.create(3, 0),
                 Position.create(5, 6)),
-                "    window.userfunction = function () {\n      return math.round(value / 10) * 10;\n    };"
+                "    window.userFunction = function () {\n      return Math.round(value / 10) * 10;\n    };"
             )
         ];
         const formatter = new Formatter(text, options);
@@ -73,7 +73,7 @@ endscript`;
             TextEdit.replace(Range.create(
                 Position.create(3, 0),
                 Position.create(5, 6)),
-                "    window.userfunction = function () {\n      return math.round(value / 10) * 10;\n    };"
+                "    window.userFunction = function () {\n      return Math.round(value / 10) * 10;\n    };"
             )
         ];
         const formatter = new Formatter(text, options);
@@ -85,8 +85,8 @@ endscript`;
         const text = `[configuration]
   [widget]
     script` +
-    `        window.userfunction = function () {` +
-  + `  return math.round(value / 10) * 10;` +
+    `        window.userFunction = function () {` +
+  + `  return Math.round(value / 10) * 10;` +
     `};`
   + `endscript`;
         const options: FormattingOptions = FormattingOptions.create(2, true);

--- a/server/src/test/scriptFormatting.test.ts
+++ b/server/src/test/scriptFormatting.test.ts
@@ -12,7 +12,7 @@ endscript`;
         const options: FormattingOptions = FormattingOptions.create(2, true);
         const expected: TextEdit[] = [
             TextEdit.replace(Range.create(
-                Position.create(0, 0),
+                Position.create(1, 0),
                 Position.create(3, 10)),
                 "  window.userFunction = function () {\n    return Math.round(value / 10) * 10;\n  };"
             )
@@ -29,7 +29,7 @@ endscript`;
         const options: FormattingOptions = FormattingOptions.create(2, true);
         const expected: TextEdit[] = [
             TextEdit.replace(Range.create(
-                Position.create(0, 0),
+                Position.create(1, 0),
                 Position.create(1, 80)),
                 "  window.userFunction = function () {\n    return Math.round(value / 10) * 10;\n  };"
             )
@@ -50,7 +50,7 @@ endscript`;
         const options: FormattingOptions = FormattingOptions.create(2, true);
         const expected: TextEdit[] = [
             TextEdit.replace(Range.create(
-                Position.create(2, 0),
+                Position.create(3, 0),
                 Position.create(5, 6)),
                 "    window.userFunction = function () {\n      return Math.round(value / 10) * 10;\n    };"
             )
@@ -71,7 +71,7 @@ endscript`;
         const options: FormattingOptions = FormattingOptions.create(2, true);
         const expected: TextEdit[] = [
             TextEdit.replace(Range.create(
-                Position.create(2, 0),
+                Position.create(3, 0),
                 Position.create(5, 6)),
                 "    window.userFunction = function () {\n      return Math.round(value / 10) * 10;\n    };"
             )

--- a/server/src/test/scriptFormatting.test.ts
+++ b/server/src/test/scriptFormatting.test.ts
@@ -1,0 +1,96 @@
+import { deepStrictEqual } from "assert";
+import { FormattingOptions, Position, Range, TextEdit } from "vscode-languageserver";
+import { Formatter } from "../formatter";
+
+suite("JavasScript code formatting", () => {
+    test("Unformatted code inside script tag alone", () => {
+        const text = `script
+        window.userFunction = function () {
+        return Math.round(value / 10) * 10;
+        }
+      endscript`;
+        const options: FormattingOptions = FormattingOptions.create(2, true);
+        const expected: TextEdit[] = [
+            TextEdit.replace(Range.create(
+                Position.create(1, 0),
+                Position.create(3, 9)),
+                "window.userfunction = function () {\n  return math.round(value / 10) * 10;\n};"
+            )
+        ];
+        const formatter = new Formatter(text, options);
+        const actual = formatter.lineByLine();
+        deepStrictEqual(actual, expected);
+    });
+
+    test("Code written in one line", () => {
+        const text = `script
+        window.userfunction = function () {return math.round(value / 10) * 10;};
+        endscript`;
+        const options: FormattingOptions = FormattingOptions.create(2, true);
+        const expected: TextEdit[] = [
+            TextEdit.replace(Range.create(
+                Position.create(1, 0),
+                Position.create(1, 80)),
+                "window.userfunction = function () {\n  return math.round(value / 10) * 10;\n};"
+            )
+        ];
+        const formatter = new Formatter(text, options);
+        const actual = formatter.lineByLine();
+        deepStrictEqual(actual, expected);
+    });
+
+    test("Unformatted code inside script tag in [configuration]", () => {
+        const text = `[configuration]
+        script
+          window.userFunction = function () {
+          return Math.round(value / 10) * 10;
+          }
+        endscript`;
+        const options: FormattingOptions = FormattingOptions.create(2, true);
+        const expected: TextEdit[] = [
+            TextEdit.replace(Range.create(
+                Position.create(2, 0),
+                Position.create(4, 11)),
+                "    window.userfunction = function () {\n      return math.round(value / 10) * 10;\n    };"
+            )
+        ];
+        const formatter = new Formatter(text, options);
+        const actual = formatter.lineByLine();
+        deepStrictEqual(actual, expected);
+    });
+
+    test("Unformatted code inside script tag in [group]", () => {
+        const text = `[group]
+        script
+          window.userFunction = function () {
+          return Math.round(value / 10) * 10;
+          }
+        endscript`;
+        const options: FormattingOptions = FormattingOptions.create(2, true);
+        const expected: TextEdit[] = [
+            TextEdit.replace(Range.create(
+                Position.create(2, 0),
+                Position.create(4, 11)),
+                "    window.userfunction = function () {\n      return math.round(value / 10) * 10;\n    };"
+            )
+        ];
+        const formatter = new Formatter(text, options);
+        const actual = formatter.lineByLine();
+        deepStrictEqual(actual, expected);
+    });
+
+    test("Correct code that doesn't need formatting", () => {
+        const text = `[configuration]
+  [widget]
+    script` +
+    `        window.userfunction = function () {` +
+  + `  return math.round(value / 10) * 10;` +
+    `};`
+  + `endscript`;
+        const options: FormattingOptions = FormattingOptions.create(2, true);
+        const expected: TextEdit[] = [];
+        const formatter = new Formatter(text, options);
+        const actual = formatter.lineByLine();
+        deepStrictEqual(actual, expected);
+    });
+});

--- a/server/src/test/scriptFormatting.test.ts
+++ b/server/src/test/scriptFormatting.test.ts
@@ -12,7 +12,7 @@ endscript`;
         const options: FormattingOptions = FormattingOptions.create(2, true);
         const expected: TextEdit[] = [
             TextEdit.replace(Range.create(
-                Position.create(1, 0),
+                Position.create(0, 0),
                 Position.create(3, 10)),
                 "  window.userFunction = function () {\n    return Math.round(value / 10) * 10;\n  };"
             )
@@ -29,7 +29,7 @@ endscript`;
         const options: FormattingOptions = FormattingOptions.create(2, true);
         const expected: TextEdit[] = [
             TextEdit.replace(Range.create(
-                Position.create(1, 0),
+                Position.create(0, 0),
                 Position.create(1, 80)),
                 "  window.userFunction = function () {\n    return Math.round(value / 10) * 10;\n  };"
             )
@@ -50,7 +50,7 @@ endscript`;
         const options: FormattingOptions = FormattingOptions.create(2, true);
         const expected: TextEdit[] = [
             TextEdit.replace(Range.create(
-                Position.create(3, 0),
+                Position.create(2, 0),
                 Position.create(5, 6)),
                 "    window.userFunction = function () {\n      return Math.round(value / 10) * 10;\n    };"
             )
@@ -71,7 +71,7 @@ endscript`;
         const options: FormattingOptions = FormattingOptions.create(2, true);
         const expected: TextEdit[] = [
             TextEdit.replace(Range.create(
-                Position.create(3, 0),
+                Position.create(2, 0),
                 Position.create(5, 6)),
                 "    window.userFunction = function () {\n      return Math.round(value / 10) * 10;\n    };"
             )

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -665,7 +665,7 @@
         "body": [
             "script",
             "  window.${1:userFunction} = function () {",
-            "    ${2:return Math.round(value / 10) * 10;}",
+            "    ${2}",
             "  };",
             "endscript"
         ]

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -665,8 +665,8 @@
         "body": [
             "script",
             "  window.${1:userFunction} = function () {",
-            "  ${2:return Math.round(value / 10) * 10;}",
-            "  }",
+            "    ${2:return Math.round(value / 10) * 10;}",
+            "  };",
             "endscript"
         ]
     }


### PR DESCRIPTION
JavaScript formatting inside `script` tags via [esprima](https://esprima.org/) & [escodegen](https://github.com/estools/escodegen/wiki/API)

![formatting_upd](https://user-images.githubusercontent.com/15448200/60826272-277af480-a1b6-11e9-96d2-4787c02d6243.gif)
