### PR TITLE
Add evaluate settings

### DIFF
--- a/server/descriptions.md
+++ b/server/descriptions.md
@@ -997,7 +997,7 @@ Define the Metric.
   
 ## metrics  
   
-Retrieves a list of metrics collected by the entity.  
+Supported only with the evaluate-expression setting. List of metrics for which series collections are loaded with the same entity and tags as in the main query.
   
 ## metriclabel  
   

--- a/server/descriptions.md
+++ b/server/descriptions.md
@@ -418,6 +418,26 @@ Override grouped series legend when `group=entity`.
   
 Define the wait period after ATSD handles a server processing error before refreshing data.  
   
+## evaluateexpression  
+  
+Expression evaluated for each timestamp.  
+  
+## evaluatelibs  
+  
+Libraries used for expression evaluation.  
+  
+## evaluatemode  
+  
+Evaluation mode: can be strict or not strict.  
+  
+## evaluatescript  
+  
+Script used for expression evaluation for each timestamp.  
+  
+## evaluatetimezone  
+  
+Regularizes series into DAY (and larger periods) due to calendar alignment.  
+  
 ## exactmatch  
   
 Ignore series with tags, other than those specified in the series configuration.  
@@ -974,6 +994,10 @@ Supported wildcards: `*` and `?`.
 ## metric  
   
 Define the Metric.  
+  
+## metrics  
+  
+Retrieves a list of metrics collected by the entity.  
   
 ## metriclabel  
   

--- a/server/descriptions.md
+++ b/server/descriptions.md
@@ -418,25 +418,25 @@ Override grouped series legend when `group=entity`.
   
 Define the wait period after ATSD handles a server processing error before refreshing data.  
   
-## evaluateexpression  
+## evaluateexpression
   
-Expression evaluated for each timestamp.  
+MVEL expression text applied to the series collections retrieved at the previous transformation step.  
   
 ## evaluatelibs  
   
-Libraries used for expression evaluation.  
+List of MVEL script files imported in the expression context. The scripts can be uploaded on the Data > MVEL Script Viewer page.
   
 ## evaluatemode  
   
-Evaluation mode: can be strict or not strict.  
+Data consistency mode: STRICT or NOT_STRICT (default). Strict mode generates error when some of the joined data is missing.
   
 ## evaluatescript  
   
-Script used for expression evaluation for each timestamp.  
+MVEL script file imported in the expression context. The script can be uploaded on the Data > MVEL Script Viewer page.
   
 ## evaluatetimezone  
   
-Regularizes series into DAY (and larger periods) due to calendar alignment.  
+Timezone used in calendar alignment. The default is the server timezone. List of supported timezone identifiers: https://axibase.com/docs/atsd/shared/timezone-list.html
   
 ## exactmatch  
   

--- a/server/dictionary.json
+++ b/server/dictionary.json
@@ -2124,6 +2124,7 @@
             "displayName": "evaluate-mode",
             "type": "enum",
             "section": "series",
+            "example": "STRICT",
             "defaultValue": "NOT_STRICT",
             "enum": [
                 "STRICT",

--- a/server/dictionary.json
+++ b/server/dictionary.json
@@ -2106,6 +2106,51 @@
             "section": "series"
         },
         {
+            "displayName": "evaluate-expression",
+            "type": "string",
+            "example": "name LIKE 'cpu*'",
+            "section": "series",
+            "excludes": [
+                "evaluate-script"
+            ]
+        },
+        {
+            "displayName": "evaluate-libs",
+            "type": "string[]",
+            "example": "helpers.mvl,my-lib.mvel",
+            "section": "series"
+        },
+        {
+            "displayName": "evaluate-mode",
+            "type": "string",
+            "example": "NOT_STRICT",
+            "section": "series",
+            "defaultValue": "NOT_STRICT",
+            "possibleValues": [
+                {
+                    "value": "STRICT"
+                },
+                {
+                    "value": "NOT_STRICT"
+                }
+            ]
+        },
+        {
+            "displayName": "evaluate-script",
+            "type": "string",
+            "example": "script-file.mvel",
+            "section": "series",
+            "excludes": [
+                "evaluate-expression"
+            ]
+        },
+        {
+            "displayName": "evaluate-timezone",
+            "type": "string",
+            "section": "series",
+            "example": "Europe/Moscow"
+        },
+        {
             "displayName": "exact-match",
             "type": "boolean",
             "example": true,
@@ -4086,6 +4131,12 @@
                 "attribute",
                 "table"
             ]
+        },
+        {
+            "displayName": "metrics",
+            "type": "string[]",
+            "example": "disk_used, memused",
+            "section": "series"
         },
         {
             "displayName": "metric-label",

--- a/server/dictionary.json
+++ b/server/dictionary.json
@@ -2116,7 +2116,8 @@
         },
         {
             "displayName": "evaluate-libs",
-            "type": "string[]",
+            "type": "string",
+            "multiple": true,
             "example": "helpers.mvl, my-lib.mvel",
             "section": "series"
         },
@@ -4130,7 +4131,8 @@
         },
         {
             "displayName": "metrics",
-            "type": "string[]",
+            "type": "string",
+            "multiple": true,
             "example": "disk_used, memused",
             "section": "series"
         },

--- a/server/dictionary.json
+++ b/server/dictionary.json
@@ -2117,22 +2117,18 @@
         {
             "displayName": "evaluate-libs",
             "type": "string[]",
-            "example": "helpers.mvl,my-lib.mvel",
+            "example": "helpers.mvl, my-lib.mvel",
             "section": "series"
         },
         {
             "displayName": "evaluate-mode",
-            "type": "string",
+            "type": "enum",
             "example": "NOT_STRICT",
             "section": "series",
             "defaultValue": "NOT_STRICT",
-            "possibleValues": [
-                {
-                    "value": "STRICT"
-                },
-                {
-                    "value": "NOT_STRICT"
-                }
+            "enum": [
+                "STRICT",
+                "NOT_STRICT"
             ]
         },
         {

--- a/server/dictionary.json
+++ b/server/dictionary.json
@@ -2123,7 +2123,6 @@
         {
             "displayName": "evaluate-mode",
             "type": "enum",
-            "example": "NOT_STRICT",
             "section": "series",
             "defaultValue": "NOT_STRICT",
             "enum": [

--- a/server/dictionary.schema.json
+++ b/server/dictionary.schema.json
@@ -76,6 +76,7 @@
             "enum": [
               "boolean",
               "string",
+              "string[]",
               "enum",
               "number",
               "interval",

--- a/server/dictionary.schema.json
+++ b/server/dictionary.schema.json
@@ -145,6 +145,10 @@
             "description": "[Optional] Can this setting be repeated or not. Default is false",
             "type": "boolean"
           },
+          "multiple": {
+            "description": "[Optional] value is a list of given type",
+            "type": "boolean"
+          },
           "enum": {
             "description": "[Optional] Possible values constraint. Default is 'no constraint'. RegExp is supported",
             "type": "array",

--- a/server/src/completionProvider.ts
+++ b/server/src/completionProvider.ts
@@ -256,7 +256,8 @@ endif
             return [];
         }
         switch (setting.type) {
-            case "string": {
+            case "string":
+            case "string[]": {
                 return this.completeStringSettingValue(setting);
             }
             case "number":

--- a/server/src/defaultSetting.ts
+++ b/server/src/defaultSetting.ts
@@ -17,6 +17,8 @@ interface ValueRange {
     excluded: boolean;
 }
 
+type SettingValueType =
+    "string" | "number" | "integer" | "boolean" | "enum" | "interval" | "date" | "object" | "string[]";
 /**
  * Holds the description of a setting and corresponding methods.
  */
@@ -91,7 +93,7 @@ export class DefaultSetting {
      * The type of the setting.
      * Possible values: string, number, integer, boolean, enum, interval, date, string[]
      */
-    public readonly type: string = "";
+    public readonly type: SettingValueType = "string";
     /**
      * Type of the widget were setting is applicable, for example,
      * gradient-count is applicable for gauge, treemap and calendar.
@@ -157,7 +159,7 @@ export class DefaultSetting {
         if (this.example != null && this.example !== "") {
             result += `Example: ${this.displayName} = ${this.example}  \n`;
         }
-        if (this.type != null && this.type !== "") {
+        if (this.type != null) {
             result += `Type: ${this.type}  \n`;
         }
         if (this.defaultValue != null && this.defaultValue !== "") {

--- a/server/src/defaultSetting.ts
+++ b/server/src/defaultSetting.ts
@@ -89,7 +89,7 @@ export class DefaultSetting {
     public readonly section?: string | string[];
     /**
      * The type of the setting.
-     * Possible values: string, number, integer, boolean, enum, interval, date
+     * Possible values: string, number, integer, boolean, enum, interval, date, string[]
      */
     public readonly type: string = "";
     /**

--- a/server/src/defaultSetting.ts
+++ b/server/src/defaultSetting.ts
@@ -17,8 +17,6 @@ interface ValueRange {
     excluded: boolean;
 }
 
-type SettingValueType =
-    "string" | "number" | "integer" | "boolean" | "enum" | "interval" | "date" | "object" | "string[]";
 /**
  * Holds the description of a setting and corresponding methods.
  */
@@ -91,9 +89,14 @@ export class DefaultSetting {
     public readonly section?: string | string[];
     /**
      * The type of the setting.
-     * Possible values: string, number, integer, boolean, enum, interval, date, string[]
+     * Possible values: string, number, integer, boolean, enum, interval, date
      */
-    public readonly type: SettingValueType = "string";
+    public readonly type: string = "";
+    /**
+     * Indicates that value is a list of given type
+     * For example, string[] is comma separated strings list
+     */
+    public readonly multiple: boolean = false;
     /**
      * Type of the widget were setting is applicable, for example,
      * gradient-count is applicable for gauge, treemap and calendar.
@@ -159,7 +162,7 @@ export class DefaultSetting {
         if (this.example != null && this.example !== "") {
             result += `Example: ${this.displayName} = ${this.example}  \n`;
         }
-        if (this.type != null) {
+        if (this.type != null && this.type !== "") {
             result += `Type: ${this.type}  \n`;
         }
         if (this.defaultValue != null && this.defaultValue !== "") {

--- a/server/src/relatedSettingsRules/index.ts
+++ b/server/src/relatedSettingsRules/index.ts
@@ -5,6 +5,8 @@ import { RelatedSettingsRule } from "./utils/interfaces";
 import colorsThresholds from "./valueValidation/colorsThresholds";
 import forecastAutoCountAndEigentripleLimit from "./valueValidation/forecastAutoCountAndEigentripleLimit";
 import forecastEndTime from "./valueValidation/forecastEndTime";
+import forecastSsaGroupAutoUnion from "./valueValidation/forecastSsaGroupAutoUnion";
+import forecastSsaGroupManualGroups from "./valueValidation/forecastSsaGroupManualGroups";
 import forecastStartTime from "./valueValidation/forecastStartTime";
 import startEndTime from "./valueValidation/startEndTime";
 
@@ -16,7 +18,9 @@ const rulesBySection: Map<string, RelatedSettingsRule[]> = new Map<string, Relat
             forecastStartTime,
             forecastAutoCountAndEigentripleLimit,
             requiredSettings,
-            noUselessSettingsForSeries
+            noUselessSettingsForSeries,
+            forecastSsaGroupAutoUnion,
+            forecastSsaGroupManualGroups
         ]
     ],
     [

--- a/server/src/relatedSettingsRules/valueValidation/forecastSsaGroupAutoUnion.ts
+++ b/server/src/relatedSettingsRules/valueValidation/forecastSsaGroupAutoUnion.ts
@@ -1,0 +1,22 @@
+import { Diagnostic } from "vscode-languageserver";
+import { Section } from "../../configTree/section";
+import { createDiagnostic } from "../../util";
+import { RelatedSettingsRule } from "../utils/interfaces";
+
+const rule: RelatedSettingsRule = {
+    name: "Validates forecast-ssa-group-auto-union value syntax",
+    check(section: Section): Diagnostic | void {
+        const setting = section.getSettingFromTree("forecast-ssa-group-auto-union");
+        if (setting === void 0) {
+            return;
+        }
+        if (!/^[a-z\s,;-]+$/.test(setting.value)) {
+            return createDiagnostic(
+                setting.textRange,
+                "Incorrect group union syntax"
+            );
+        }
+    }
+};
+
+export default rule;

--- a/server/src/relatedSettingsRules/valueValidation/forecastSsaGroupManualGroups.ts
+++ b/server/src/relatedSettingsRules/valueValidation/forecastSsaGroupManualGroups.ts
@@ -1,0 +1,22 @@
+import { Diagnostic } from "vscode-languageserver";
+import { Section } from "../../configTree/section";
+import { createDiagnostic } from "../../util";
+import { RelatedSettingsRule } from "../utils/interfaces";
+
+const rule: RelatedSettingsRule = {
+    name: "Validates forecast-ssa-group-manual-groups value syntax",
+    check(section: Section): Diagnostic | void {
+        const setting = section.getSettingFromTree("forecast-ssa-group-manual-groups");
+        if (setting === void 0) {
+            return;
+        }
+        if (!/^[\d\s,;-]+$/.test(setting.value)) {
+            return createDiagnostic(
+                setting.textRange,
+                "Incorrect group syntax"
+            );
+        }
+    }
+};
+
+export default rule;

--- a/server/src/setting.ts
+++ b/server/src/setting.ts
@@ -113,6 +113,15 @@ export class Setting extends DefaultSetting {
           range);
         break;
       }
+      case "string[]": {
+        if (!this.isValidStringArray(this.value)) {
+          result = createDiagnostic(
+            range,
+            `${this.displayName} should be a comma separated list. For example, ${this.example}`,
+          );
+        }
+        break;
+      }
       case "boolean": {
         if (!BOOLEAN_REGEXP.test(this.value)) {
           result = createDiagnostic(
@@ -241,6 +250,20 @@ Current: ${this.value}`);
           n}`);
     }
     return result;
+  }
+
+  /**
+   * Check that string array has right format
+   * @param value string to test
+   */
+  private isValidStringArray(value: string) {
+    const validSingle = value.split(" ").length === 1;
+    /**
+     * Workaround in case some commas are missing
+     * For example: disk_used, cpu_used mem_used
+     */
+    const validMultiple = value.split(",").length >= value.split(" ").length;
+    return validSingle || validMultiple;
   }
 
   private findIndexInEnum(value: string) {

--- a/server/src/setting.ts
+++ b/server/src/setting.ts
@@ -11,28 +11,6 @@ import {
 } from "./regExpressions";
 import { createDiagnostic } from "./util";
 
-interface SpecificValueCheck {
-  errMsg: string;
-  isIncorrect: (value: string) => boolean;
-}
-
-const specificValueChecksMap: Map<string, SpecificValueCheck> = new Map([
-  ["forecastssagroupmanualgroups", {
-    errMsg: "Incorrect group syntax",
-    isIncorrect: (value: string) => {
-      const regex = /^[\d\s,;-]+$/;
-      return !regex.test(value);
-    }
-  }],
-  ["forecastssagroupautounion", {
-    errMsg: "Incorrect group union syntax",
-    isIncorrect: (value: string) => {
-      const regex = /^[a-z\s,;-]+$/;
-      return !regex.test(value);
-    }
-  }]
-]);
-
 /**
  * In addition to DefaultSetting contains specific fields.
  */
@@ -86,11 +64,6 @@ export class Setting extends DefaultSetting {
             result = createDiagnostic(range,
               `${this.displayName} must contain only the following:\n * ${enumList}`);
           }
-          break;
-        }
-        const specCheck = specificValueChecksMap.get(this.name);
-        if (specCheck && specCheck.isIncorrect(this.value)) {
-          result = createDiagnostic(range, specCheck.errMsg);
         }
         break;
       }

--- a/server/src/test/type.test.ts
+++ b/server/src/test/type.test.ts
@@ -1,4 +1,5 @@
-import { Diagnostic, DiagnosticSeverity, Range } from "vscode-languageserver";
+import { deepStrictEqual } from "assert";
+import { Diagnostic, DiagnosticSeverity, Position, Range } from "vscode-languageserver";
 import { dateError, supportedUnits } from "../messageUtil";
 import { createDiagnostic, createRange } from "../util";
 import { Validator } from "../validator";
@@ -671,5 +672,107 @@ start-time = ${template}
       "Incorrect interval syntax: + .5 * week");
     const actual = validator.lineByLine();
     assert.deepStrictEqual(actual, expected, `Config:\n${config}`);
+  });
+});
+
+suite("string[] type tests", () => {
+  test("Commas are missing", () => {
+    const config = `[configuration]
+          [group]
+          [widget]
+              type = chart
+              metric = a
+              [column]
+                  [series]
+                  entity = b
+                  metrics = c d e`;
+    const validator = new Validator(config);
+    const actualDiagnostics = validator.lineByLine();
+    const expectedDiagnostic = createDiagnostic(
+      Range.create(Position.create(8, 18), Position.create(8, 25)),
+      "metrics should be a comma separated list. For example, disk_used, memused",
+      DiagnosticSeverity.Error
+    );
+    deepStrictEqual(actualDiagnostics, [expectedDiagnostic]);
+  });
+
+  test("Some commas are missing", () => {
+    const config = `[configuration]
+          [group]
+          [widget]
+              type = chart
+              metric = a
+              [column]
+                  [series]
+                  entity = b
+                  metrics = c, d e`;
+    const validator = new Validator(config);
+    const actualDiagnostics = validator.lineByLine();
+    const expectedDiagnostic = createDiagnostic(
+      Range.create(Position.create(8, 18), Position.create(8, 25)),
+      "metrics should be a comma separated list. For example, disk_used, memused",
+      DiagnosticSeverity.Error
+    );
+    deepStrictEqual(actualDiagnostics, [expectedDiagnostic]);
+  });
+
+  test("Correct setting of string[] type, no spaces", () => {
+    const config = `[configuration]
+          [group]
+          [widget]
+              type = chart
+              metric = a
+              [column]
+                  [series]
+                  entity = b
+                  metrics = c,d,e`;
+    const validator = new Validator(config);
+    const actualDiagnostics = validator.lineByLine();
+    deepStrictEqual(actualDiagnostics, []);
+  });
+
+  test("Correct setting of string[] type with spaces", () => {
+    const config = `[configuration]
+          [group]
+          [widget]
+              type = chart
+              metric = a
+              [column]
+                  [series]
+                  entity = b
+                  metrics = c, d, e`;
+    const validator = new Validator(config);
+    const actualDiagnostics = validator.lineByLine();
+    deepStrictEqual(actualDiagnostics, []);
+  });
+
+  test("Correct setting of string[], single value", () => {
+    const config = `[configuration]
+          [group]
+          [widget]
+              type = chart
+              metric = a
+              [column]
+                  [series]
+                  entity = b
+                  metrics = c`;
+    const validator = new Validator(config);
+    const actualDiagnostics = validator.lineByLine();
+    deepStrictEqual(actualDiagnostics, []);
+  });
+
+  test("Correct setting of string[] type, some spaces are missing", () => {
+    const config = `[configuration]
+          [group]
+          [widget]
+              type = chart
+              metric = a
+              [column]
+                  [series]
+                  entity = b
+                  metrics = c,d, e`;
+    const validator = new Validator(config);
+    const actualDiagnostics = validator.lineByLine();
+    deepStrictEqual(actualDiagnostics, []);
   });
 });

--- a/server/src/validator.ts
+++ b/server/src/validator.ts
@@ -973,6 +973,10 @@ export class Validator {
             }
         }
 
+        if (setting.multiple) {
+            this.checkMultipleSetting(setting);
+        }
+
         if (!setting.multiLine) {
             this.checkRepetition(setting);
         } else {
@@ -1215,6 +1219,30 @@ export class Validator {
                     DiagnosticSeverity.Warning
                 ));
             }
+        }
+    }
+
+    /**
+     * Check that multiple type setting has right value format
+     * @param setting - config setting to test
+     */
+    private checkMultipleSetting(setting: Setting) {
+        const { displayName, example, textRange, value } = setting;
+        const validSingle = value.split(" ").length === 1;
+        /**
+         * Workaround in case some commas are missing
+         * For example: disk_used, cpu_used mem_used
+         */
+        const validMultiple = value.split(",").length >= value.split(" ").length;
+        /**
+         * If multiple setting is not correct, create diagnostic
+         */
+        if (!validSingle && !validMultiple) {
+            this.result.push(createDiagnostic(
+                textRange,
+                `${displayName} should be a comma separated list. For example, ${example}`,
+                DiagnosticSeverity.Error,
+            ));
         }
     }
 


### PR DESCRIPTION
Closes #365 

Added UDF settings to dictionary. According to @VeselovAlex [comment](https://github.com/axibase/axibase-charts-vscode/issues/365#issuecomment-518150617) didn't specify dependency relations between `metrics` and `evaluation-expression`. Though made `evaluate-script` and `evaluate-expression` mutually exclusive.

Also introduced new settings type `string[]` for convenient validation that setting represents comma separated list, but not just string concatenated with spaces.

![image](https://user-images.githubusercontent.com/15448200/62476486-c728a400-b7af-11e9-9724-fdd83f3235cf.png)
